### PR TITLE
fix: 🐛 nested anchor in note card and list item

### DIFF
--- a/src/components/notes/note-card.tsx
+++ b/src/components/notes/note-card.tsx
@@ -30,17 +30,17 @@ export const NoteCard = ({
   const displayContent = truncate(note.content, MAX_CONTENT_LENGTH);
 
   return (
-    <Link
-      className="group block focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-      href={`/notes/${note.id}`}
-    >
-      <Card className="relative flex cursor-pointer flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-lg">
-        <PinNoteButton
-          className="absolute top-2 right-2 z-10"
-          noteId={toNoteId(note.id)}
-          pinned={Boolean(note.pinnedAt)}
-        />
-        <CardContent className="flex-1 py-4">
+    <Card className="group relative flex cursor-pointer flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-lg">
+      <PinNoteButton
+        className="absolute top-2 right-2 z-10"
+        noteId={toNoteId(note.id)}
+        pinned={Boolean(note.pinnedAt)}
+      />
+      <CardContent className="flex-1 py-4">
+        <Link
+          className="block focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          href={`/notes/${note.id}`}
+        >
           <p className="truncate text-sm leading-relaxed text-foreground transition-colors group-hover:text-foreground/90">
             {query
               ? getHighlightedParts(displayContent, query).map((part) => {
@@ -57,17 +57,17 @@ export const NoteCard = ({
                 })
               : displayContent}
           </p>
-        </CardContent>
-        <CardFooter className="flex flex-col items-start gap-2 border-t">
-          <span className="flex items-center gap-2 text-xs text-muted-foreground transition-colors group-hover:text-muted-foreground/80">
-            {formatDate(note.createdAt)}
-            {note.remindAt && <BellIcon className="h-3 w-3" />}
-          </span>
-          {tags.length > 0 && (
-            <NoteTags currentParams={currentParams} tags={tags} />
-          )}
-        </CardFooter>
-      </Card>
-    </Link>
+        </Link>
+      </CardContent>
+      <CardFooter className="flex flex-col items-start gap-2 border-t">
+        <span className="flex items-center gap-2 text-xs text-muted-foreground transition-colors group-hover:text-muted-foreground/80">
+          {formatDate(note.createdAt)}
+          {note.remindAt && <BellIcon className="h-3 w-3" />}
+        </span>
+        {tags.length > 0 && (
+          <NoteTags currentParams={currentParams} tags={tags} />
+        )}
+      </CardFooter>
+    </Card>
   );
 };

--- a/src/components/notes/note-list-item.tsx
+++ b/src/components/notes/note-list-item.tsx
@@ -29,27 +29,29 @@ export const NoteListItem = ({
   const displayContent = truncate(note.content, MAX_CONTENT_LENGTH);
 
   return (
-    <Link
-      className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-      href={`/notes/${note.id}`}
-    >
+    <div className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted">
       <div className="min-w-0 flex-1">
-        <p className="truncate text-sm leading-relaxed text-foreground transition-colors group-hover:text-foreground/90">
-          {query
-            ? getHighlightedParts(displayContent, query).map((part) => {
-                return part.match ? (
-                  <mark
-                    className="bg-yellow-200 text-inherit dark:bg-yellow-800"
-                    key={part.id}
-                  >
-                    {part.text}
-                  </mark>
-                ) : (
-                  <span key={part.id}>{part.text}</span>
-                );
-              })
-            : displayContent}
-        </p>
+        <Link
+          className="block focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+          href={`/notes/${note.id}`}
+        >
+          <p className="truncate text-sm leading-relaxed text-foreground transition-colors group-hover:text-foreground/90">
+            {query
+              ? getHighlightedParts(displayContent, query).map((part) => {
+                  return part.match ? (
+                    <mark
+                      className="bg-yellow-200 text-inherit dark:bg-yellow-800"
+                      key={part.id}
+                    >
+                      {part.text}
+                    </mark>
+                  ) : (
+                    <span key={part.id}>{part.text}</span>
+                  );
+                })
+              : displayContent}
+          </p>
+        </Link>
         {tags.length > 0 && (
           <div className="mt-1">
             <NoteTags currentParams={currentParams} tags={tags} />
@@ -67,6 +69,6 @@ export const NoteListItem = ({
           size="icon-xs"
         />
       </div>
-    </Link>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary

- Remove the card-level `<Link>` wrapper from `NoteCard` and `NoteListItem`, replacing it with a plain `<div>`
- Wrap only the note content `<p>` in a `<Link>` — this is the actual navigable element
- Fixes invalid nested `<a>` elements caused by `NoteTags` rendering `<Link>` elements inside the card link, which produced hydration errors

## Why

`<a>` cannot contain a nested `<a>` per the HTML spec. The card-as-link pattern meant every tag badge link inside was invalid. Making only the content the link restores valid HTML, keeps `NoteTags` as a pure Server Component with real `<Link>` elements (full SSR, no `useRouter`), and preserves all hover/focus styles via the `group` class on the outer div.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the interactive layout structure of note cards and note list items. Previously, clicking anywhere on a note card or row would navigate to that note. Now navigation requires clicking the note text content directly. Focus indicators and hover states have been adjusted to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->