### PR TITLE
feat: ✨ add folder panel with drag-and-drop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ src/
       new/          # New note page
     settings/       # Settings page (profile, export, import)
   components/       # React components
+    folders/          # Folder management (panel, create, rename, delete)
     notes/          # Note-related components (cards, filters, actions, etc.)
       assets/       # Asset components (uploader, preview, list)
     settings/       # Settings-related components (profile form, export, import)
@@ -71,6 +72,8 @@ data/
 - **`"use cache"` directive:** Read actions (e.g., `get-note.ts`, `get-notes.ts`) use the `"use cache"` directive with `cacheTag("notes")` for automatic caching. This is enabled by `experimental: { useCache: true }` in `next.config.ts`. Do **not** use `"use cache"` on time-dependent queries (e.g., "find reminders where `remindAt <= now()`") -- the cached result goes stale immediately since `now()` changes every call.
 - **Navigation links** in the top nav use `Button` + `Link` + `Tooltip` + `Kbd` with single-letter hotkeys (e.g., `h` for home, `n` for new note, `s` for settings). No dropdowns -- keep it flat and minimal.
 - **Global hotkeys** are registered in `HotkeysProvider` (`src/components/hotkeys-provider.tsx`). When adding a new nav route, also register its hotkey there.
+- **`FolderPanel`** is a `"use client"` component rendered via `createPortal` → `document.body` as a fixed floating pill at the bottom center of the screen. It is always visible on `/notes` (even with 0 folders) and hidden on all other pages unless a drag is in progress. It receives `folders` as a server-side prop from `layout.tsx` (avoids async load delay), reads `activeFolder` internally via `useQueryStates`, and acts as both a filter surface (click to filter by folder) and a drag-and-drop target (drop a note card onto a folder chip to move it). Use a `mounted` state guard (`useEffect` → `setMounted(true)`) before calling `createPortal` to prevent SSR errors. Wrap `<FolderPanel>` in `<Suspense>` in `layout.tsx` because it uses `useSearchParams` internally via `nuqs`.
+- **Tagging** — tags are stored in a separate `tags` table with a many-to-many `note_tags` join table. `getTagsForNotes(noteIds)` bulk-fetches tags for a list of note IDs and returns a `Record<noteId, SelectTag[]>` map. Tags are rendered as `Badge` links on note cards and list items via `NoteTags`; clicking a tag sets the `tag` search param to filter the notes list. The `TagInput` component in the edit form handles inline tag creation and deletion. Active tag and folder filter chips are rendered by `ActiveFiltersChip` (replaces the old `TagFilterChip`).
 
 ### Forms
 
@@ -118,6 +121,7 @@ If any step fails, fix the issue and re-run from that step. Do not move on until
 - **Environment variables** are validated in `src/env.ts` using `@t3-oss/env-nextjs` with Zod. Import from `@/env` -- never use `process.env` directly. The only env var is `DATABASE_PATH` (defaults to `file:./data/notras.db`). `NODE_ENV` is also validated as a shared env var.
 - **Database schemas** are in `src/server/db/schemas/`. Use Drizzle ORM query builder, not raw SQL. Dialect is SQLite (`sqliteTable`). New schema modules must be spread into the `schema` object in `src/server/db/index.ts`.
 - **Components** use Shadcn UI primitives from `@/components/ui/`. Add new Shadcn components via the CLI (`pnpm dlx shadcn@latest add <component>`). Always prefer a Shadcn component over hand-rolling custom UI -- check the registry first (`shadcn_search_items_in_registries`) before building something from scratch.
+- **Conditional classes:** Use `cn()` from `@/lib/ui/utils` for all conditional or merged Tailwind class strings -- never template literals. `cn` wraps `clsx` + `tailwind-merge`, so it handles conflict resolution correctly (e.g., `cn("px-3", isActive && "bg-primary/10")`).
 - **Icons** come from `lucide-react` exclusively. Always import using the `Icon` suffix (e.g., `PlusIcon` not `Plus`, `SettingsIcon` not `Settings`).
 - **Zod v4:** The project uses Zod 4. Use `z.email()` instead of `z.string().email()`. Use `z.treeifyError(error)` instead of `error.flatten().fieldErrors` -- the return shape is `{ errors: string[], properties: Record<key, { errors: string[] }> }`.
 - Use `satisfies` for type narrowing when possible (e.g., config objects).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A personal, single-user note-taking app that runs locally with a SQLite database
 - filter by time period (today, yesterday, this week, this month, all time)
 - sort by newest, oldest, or recently updated
 - toggle between grid and list views
+- tag notes and filter by tag
+- organize notes into folders with drag-and-drop
 - attach images and PDFs to notes (images auto-optimized to WebP)
 - extract links from note content and display them in a sidebar
 - export notes as a zip and import from backup (merge or mirror)
@@ -48,6 +50,7 @@ A personal, single-user note-taking app that runs locally with a SQLite database
 - [React Hook Form](https://react-hook-form.com)
 - [next-safe-action](https://next-safe-action.dev) (type-safe server actions)
 - [Motion](https://motion.dev)
+- [dnd-kit](https://dndkit.com) (drag-and-drop)
 - [Sonner](https://sonner.emilkowal.ski)
 - [Lucide](https://lucide.dev)
 - [nuqs](https://nuqs.47ng.com) (URL search state)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@dnd-kit/dom": "0.3.2",
+    "@dnd-kit/react": "0.3.2",
     "@hookform/resolvers": "5.2.2",
     "@libsql/client": "0.17.0",
     "@next-safe-action/adapter-react-hook-form": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/dom':
+        specifier: 0.3.2
+        version: 0.3.2
+      '@dnd-kit/react':
+        specifier: 0.3.2
+        version: 0.3.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
@@ -365,6 +371,27 @@ packages:
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
     engines: {node: '>=14'}
+
+  '@dnd-kit/abstract@0.3.2':
+    resolution: {integrity: sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==}
+
+  '@dnd-kit/collision@0.3.2':
+    resolution: {integrity: sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==}
+
+  '@dnd-kit/dom@0.3.2':
+    resolution: {integrity: sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==}
+
+  '@dnd-kit/geometry@0.3.2':
+    resolution: {integrity: sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==}
+
+  '@dnd-kit/react@0.3.2':
+    resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.3.2':
+    resolution: {integrity: sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==}
 
   '@dotenvx/dotenvx@1.52.0':
     resolution: {integrity: sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w==}
@@ -1620,6 +1647,9 @@ packages:
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@preact/signals-core@1.13.0':
+    resolution: {integrity: sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -6671,6 +6701,45 @@ snapshots:
 
   '@ctrl/tinycolor@4.2.0': {}
 
+  '@dnd-kit/abstract@0.3.2':
+    dependencies:
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/collision': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.3.2':
+    dependencies:
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.3.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/dom': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.3.2':
+    dependencies:
+      '@preact/signals-core': 1.13.0
+      tslib: 2.8.1
+
   '@dotenvx/dotenvx@1.52.0':
     dependencies:
       commander: 11.1.0
@@ -7624,6 +7693,8 @@ snapshots:
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@preact/signals-core@1.13.0': {}
 
   '@radix-ui/number@1.1.1': {}
 

--- a/src/actions/create-folder.ts
+++ b/src/actions/create-folder.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { updateTag } from "next/cache";
+
+import { serverAction } from "@/lib/authorized";
+import { createFolderSchema } from "@/server/schemas/folder-schemas";
+import { getFolderService } from "@/server/services/folder-service";
+
+export async function createFolder(formData: FormData) {
+  const { name } = createFolderSchema.parse({
+    name: formData.get("name"),
+  });
+
+  await serverAction(async (userId) => {
+    await getFolderService().create(userId, name);
+  });
+
+  updateTag("folders");
+}

--- a/src/actions/delete-folder.ts
+++ b/src/actions/delete-folder.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { updateTag } from "next/cache";
+
+import type { FolderId } from "@/lib/id";
+
+import { serverAction } from "@/lib/authorized";
+import { getFolderService } from "@/server/services/folder-service";
+
+export async function deleteFolder(folderId: FolderId) {
+  await serverAction(async (userId) => {
+    await getFolderService().delete(userId, folderId);
+  });
+
+  updateTag("folders");
+  updateTag("notes");
+}

--- a/src/actions/get-folders.ts
+++ b/src/actions/get-folders.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { cacheTag } from "next/cache";
+
+import { serverAction } from "@/lib/authorized";
+import { getFolderService } from "@/server/services/folder-service";
+
+export async function getFolders() {
+  return serverAction(async (userId) => {
+    "use cache";
+
+    const result = await getFolderService().getAll(userId);
+
+    cacheTag("folders");
+
+    return result;
+  });
+}

--- a/src/actions/get-folders.ts
+++ b/src/actions/get-folders.ts
@@ -11,7 +11,7 @@ export async function getFolders() {
 
     const result = await getFolderService().getAll(userId);
 
-    cacheTag("folders");
+    cacheTag("notes");
 
     return result;
   });

--- a/src/actions/get-notes.ts
+++ b/src/actions/get-notes.ts
@@ -8,6 +8,7 @@ import type { NoteSearchParams } from "@/lib/notes-search-params";
 import type { PinFilter } from "@/server/repositories/note-repository";
 
 import { serverAction } from "@/lib/authorized";
+import { toFolderId } from "@/lib/id";
 import { parsers } from "@/lib/notes-search-params";
 import { getNoteService } from "@/server/services/note-service";
 import { getTagService } from "@/server/services/tag-service";
@@ -21,10 +22,12 @@ export async function getNotes(
   return serverAction(async (userId) => {
     "use cache";
 
-    const { q: query, sort, tag, time } = searchParams;
+    const { folder, q: query, sort, tag, time } = searchParams;
+    const folderId = folder ? toFolderId(folder) : undefined;
 
     const result = await getNoteService().list(userId, {
       ...options,
+      folderId,
       query,
       sort,
       tag,

--- a/src/actions/get-notes.ts
+++ b/src/actions/get-notes.ts
@@ -23,7 +23,10 @@ export async function getNotes(
     "use cache";
 
     const { folder, q: query, sort, tag, time } = searchParams;
-    const folderId = folder ? toFolderId(folder) : undefined;
+    const folderId =
+      folder && /^folder_[\da-hjkmnp-tv-z]{26}$/.test(folder)
+        ? toFolderId(folder)
+        : undefined;
 
     const result = await getNoteService().list(userId, {
       ...options,

--- a/src/actions/move-note-to-folder.ts
+++ b/src/actions/move-note-to-folder.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { updateTag } from "next/cache";
+
+import type { FolderId, NoteId } from "@/lib/id";
+
+import { serverAction } from "@/lib/authorized";
+import { getFolderService } from "@/server/services/folder-service";
+
+export async function moveNoteToFolder(
+  noteId: NoteId,
+  folderId: FolderId | null,
+) {
+  await serverAction(async (userId) => {
+    await getFolderService().move(userId, noteId, folderId);
+  });
+
+  updateTag("folders");
+  updateTag("notes");
+}

--- a/src/actions/rename-folder.ts
+++ b/src/actions/rename-folder.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { updateTag } from "next/cache";
+
+import { serverAction } from "@/lib/authorized";
+import { toFolderId } from "@/lib/id";
+import { renameFolderSchema } from "@/server/schemas/folder-schemas";
+import { getFolderService } from "@/server/services/folder-service";
+
+export async function renameFolder(formData: FormData) {
+  const { folderId: folderIdRaw, name } = renameFolderSchema.parse({
+    folderId: formData.get("folderId"),
+    name: formData.get("name"),
+  });
+
+  const folderId = toFolderId(folderIdRaw);
+
+  await serverAction(async (userId) => {
+    await getFolderService().rename(userId, folderId, name);
+  });
+
+  updateTag("folders");
+}

--- a/src/actions/rename-folder.ts
+++ b/src/actions/rename-folder.ts
@@ -20,4 +20,5 @@ export async function renameFolder(formData: FormData) {
   });
 
   updateTag("folders");
+  updateTag("notes");
 }

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -14,7 +14,7 @@ export default async function Page() {
     getProfile(),
     getNotesCount(),
     getNotes(
-      { q: "", sort: "newest", tag: "", time: "all" },
+      { folder: "", q: "", sort: "newest", tag: "", time: "all" },
       { excludePinned: true, limit: RECENT_NOTES_LIMIT },
     ),
   ]);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,10 +5,14 @@ import type { ReactNode } from "react";
 
 import { DM_Sans, Geist, Geist_Mono } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Suspense } from "react";
 
 import { getFiredRemindersCount } from "@/actions/get-fired-reminders-count";
+import { getFolders } from "@/actions/get-folders";
 import { AlphaBanner } from "@/components/alpha-banner";
+import { FolderPanel } from "@/components/folders/folder-panel";
 import { HotkeysProvider } from "@/components/hotkeys-provider";
+import { NoteDragDropProvider } from "@/components/note-drag-drop-provider";
 import { RemindersProvider } from "@/components/reminders-provider";
 import { SearchBarProvider } from "@/components/search-bar-provider";
 import { SiteFooter } from "@/components/site-footer";
@@ -50,7 +54,10 @@ export const viewport = {
 export default async function RootLayout({
   children,
 }: Readonly<{ children: ReactNode }>) {
-  const overdueCount = await getFiredRemindersCount();
+  const [overdueCount, folders] = await Promise.all([
+    getFiredRemindersCount(),
+    getFolders(),
+  ]);
 
   return (
     <html className={dmSans.variable} lang="en">
@@ -62,17 +69,22 @@ export default async function RootLayout({
             <HotkeysProvider>
               <SearchBarProvider>
                 <RemindersProvider initialCount={overdueCount}>
-                  <AlphaBanner />
-                  <div className="flex flex-col">
-                    <header className="sticky inset-x-0 top-0 isolate z-20 flex h-14 shrink-0 items-center gap-2 border-b bg-background">
-                      <SiteNav />
-                    </header>
-                    <main className="flex min-h-[calc(100svh-3.5rem)] justify-center">
-                      {children}
-                    </main>
-                    <SiteFooter />
-                  </div>
-                  <Toaster />
+                  <NoteDragDropProvider>
+                    <AlphaBanner />
+                    <div className="flex flex-col">
+                      <header className="sticky inset-x-0 top-0 isolate z-20 flex h-14 shrink-0 items-center gap-2 border-b bg-background">
+                        <SiteNav />
+                      </header>
+                      <main className="flex min-h-[calc(100svh-3.5rem)] justify-center">
+                        {children}
+                      </main>
+                      <SiteFooter />
+                    </div>
+                    <Toaster />
+                    <Suspense>
+                      <FolderPanel folders={folders} />
+                    </Suspense>
+                  </NoteDragDropProvider>
                 </RemindersProvider>
               </SearchBarProvider>
             </HotkeysProvider>

--- a/src/app/notes/(list)/page.tsx
+++ b/src/app/notes/(list)/page.tsx
@@ -3,14 +3,15 @@ import type { SearchParams } from "nuqs/server";
 import { InfoIcon, NotebookTextIcon, PinIcon, SearchIcon } from "lucide-react";
 import Link from "next/link";
 
+import { getFolders } from "@/actions/get-folders";
 import {
   getNotes,
   getTagsForNotes,
   loadSearchParams,
 } from "@/actions/get-notes";
+import { ActiveFiltersChip } from "@/components/notes/active-filters-chip";
 import { NotesList } from "@/components/notes/notes";
 import { NotesFilters } from "@/components/notes/notes-filters";
-import { TagFilterChip } from "@/components/notes/tag-filter-chip";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { toNoteId } from "@/lib/id";
 
@@ -21,19 +22,29 @@ interface PageProps {
 export default async function Page({ searchParams }: PageProps) {
   const params = await loadSearchParams(searchParams);
   const isFiltering =
-    Boolean(params.q) || params.time !== "all" || Boolean(params.tag);
+    Boolean(params.q) ||
+    params.time !== "all" ||
+    Boolean(params.tag) ||
+    Boolean(params.folder);
 
-  const [pinnedNotes, unpinnedNotes] = isFiltering
-    ? [[], await getNotes(params)]
-    : await Promise.all([
-        getNotes(params, { pinnedOnly: true }),
-        getNotes(params, { excludePinned: true }),
-      ]);
+  const [pinnedNotes, unpinnedNotes, folders] = isFiltering
+    ? [[], await getNotes(params), await getFolders()]
+    : [
+        ...(await Promise.all([
+          getNotes(params, { pinnedOnly: true }),
+          getNotes(params, { excludePinned: true }),
+        ])),
+        await getFolders(),
+      ];
 
   const allNotes = [...pinnedNotes, ...unpinnedNotes];
   const totalCount = allNotes.length;
   const noteIds = allNotes.map((n) => toNoteId(n.id));
   const tagMap = noteIds.length > 0 ? await getTagsForNotes(noteIds) : {};
+
+  const activeFolder = params.folder
+    ? folders.find((f) => f.id === params.folder)
+    : undefined;
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -41,7 +52,10 @@ export default async function Page({ searchParams }: PageProps) {
         <NotesFilters />
 
         {isFiltering && totalCount > 0 && (
-          <TagFilterChip totalCount={totalCount} />
+          <ActiveFiltersChip
+            activeFolder={activeFolder}
+            totalCount={totalCount}
+          />
         )}
 
         {totalCount === 0 ? (

--- a/src/app/notes/(list)/page.tsx
+++ b/src/app/notes/(list)/page.tsx
@@ -28,7 +28,7 @@ export default async function Page({ searchParams }: PageProps) {
     Boolean(params.folder);
 
   const [pinnedNotes, unpinnedNotes, folders] = isFiltering
-    ? [[], await getNotes(params), await getFolders()]
+    ? [[], ...(await Promise.all([getNotes(params), getFolders()]))]
     : await Promise.all([
         getNotes(params, { pinnedOnly: true }),
         getNotes(params, { excludePinned: true }),

--- a/src/app/notes/(list)/page.tsx
+++ b/src/app/notes/(list)/page.tsx
@@ -29,13 +29,11 @@ export default async function Page({ searchParams }: PageProps) {
 
   const [pinnedNotes, unpinnedNotes, folders] = isFiltering
     ? [[], await getNotes(params), await getFolders()]
-    : [
-        ...(await Promise.all([
-          getNotes(params, { pinnedOnly: true }),
-          getNotes(params, { excludePinned: true }),
-        ])),
-        await getFolders(),
-      ];
+    : await Promise.all([
+        getNotes(params, { pinnedOnly: true }),
+        getNotes(params, { excludePinned: true }),
+        getFolders(),
+      ]);
 
   const allNotes = [...pinnedNotes, ...unpinnedNotes];
   const totalCount = allNotes.length;

--- a/src/app/notes/(list)/page.tsx
+++ b/src/app/notes/(list)/page.tsx
@@ -95,6 +95,7 @@ export default async function Page({ searchParams }: PageProps) {
                 </h2>
                 <NotesList
                   currentParams={{
+                    folder: params.folder,
                     q: params.q,
                     tag: params.tag,
                     time: params.time,
@@ -117,6 +118,7 @@ export default async function Page({ searchParams }: PageProps) {
                 )}
                 <NotesList
                   currentParams={{
+                    folder: params.folder,
                     q: params.q,
                     tag: params.tag,
                     time: params.time,

--- a/src/app/notes/(list)/page.tsx
+++ b/src/app/notes/(list)/page.tsx
@@ -27,13 +27,17 @@ export default async function Page({ searchParams }: PageProps) {
     Boolean(params.tag) ||
     Boolean(params.folder);
 
-  const [pinnedNotes, unpinnedNotes, folders] = isFiltering
-    ? [[], ...(await Promise.all([getNotes(params), getFolders()]))]
-    : await Promise.all([
-        getNotes(params, { pinnedOnly: true }),
-        getNotes(params, { excludePinned: true }),
-        getFolders(),
-      ]);
+  const needsFolders = Boolean(params.folder);
+
+  const [[pinnedNotes, unpinnedNotes], folders] = await Promise.all([
+    isFiltering
+      ? Promise.all([getNotes(params), Promise.resolve([])])
+      : Promise.all([
+          getNotes(params, { pinnedOnly: true }),
+          getNotes(params, { excludePinned: true }),
+        ]),
+    needsFolders ? getFolders() : Promise.resolve([]),
+  ]);
 
   const allNotes = [...pinnedNotes, ...unpinnedNotes];
   const totalCount = allNotes.length;

--- a/src/components/folders/create-folder-button.tsx
+++ b/src/components/folders/create-folder-button.tsx
@@ -46,10 +46,13 @@ export function CreateFolderButton() {
   return (
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogTrigger asChild>
-        <Button size="sm" variant="outline">
-          <FolderPlusIcon className="size-4 sm:hidden" />
-          <span className="hidden sm:inline">new folder</span>
-        </Button>
+        <button
+          className="flex items-center rounded-full border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:border-primary/50"
+          type="button"
+        >
+          <FolderPlusIcon className="size-4" />
+          <span className="sr-only">new folder</span>
+        </button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/src/components/folders/create-folder-button.tsx
+++ b/src/components/folders/create-folder-button.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { FolderPlusIcon } from "lucide-react";
+import { useRef, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { createFolder } from "@/actions/create-folder";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+export function CreateFolderButton() {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }
+
+  function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      try {
+        await createFolder(formData);
+        setOpen(false);
+        toast.success("folder created");
+      } catch {
+        toast.error("failed to create folder. please try again.");
+      }
+    });
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <FolderPlusIcon className="size-4 sm:hidden" />
+          <span className="hidden sm:inline">new folder</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>new folder</DialogTitle>
+        </DialogHeader>
+        <form action={handleSubmit}>
+          <div className="flex flex-col gap-6 py-4">
+            <Field>
+              <FieldLabel htmlFor="folder-name">name</FieldLabel>
+              <Input
+                id="folder-name"
+                name="name"
+                placeholder="folder name"
+                ref={inputRef}
+                required
+              />
+              <FieldError />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                setOpen(false);
+              }}
+              type="button"
+              variant="outline"
+            >
+              cancel
+            </Button>
+            <Button disabled={isPending} type="submit">
+              {isPending ? "creating..." : "create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/folders/create-folder-button.tsx
+++ b/src/components/folders/create-folder-button.tsx
@@ -46,13 +46,14 @@ export function CreateFolderButton() {
   return (
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogTrigger asChild>
-        <button
-          className="flex items-center rounded-full border border-border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:border-primary/50"
+        <Button
+          className="h-auto rounded-full px-3 py-1.5"
           type="button"
+          variant="outline"
         >
           <FolderPlusIcon className="size-4" />
           <span className="sr-only">new folder</span>
-        </button>
+        </Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/src/components/folders/delete-folder-button.tsx
+++ b/src/components/folders/delete-folder-button.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Trash2Icon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import type { FolderId } from "@/lib/id";
+
+import { deleteFolder } from "@/actions/delete-folder";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+interface DeleteFolderButtonProps {
+  folderId: FolderId;
+  folderName: string;
+  iconOnly?: boolean;
+}
+
+export function DeleteFolderButton({
+  folderId,
+  folderName,
+  iconOnly = false,
+}: DeleteFolderButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      try {
+        await deleteFolder(folderId);
+        toast.success("folder deleted");
+        router.push("/notes");
+      } catch {
+        toast.error("failed to delete folder. please try again.");
+      }
+    });
+  };
+
+  return (
+    <AlertDialog onOpenChange={setOpen} open={open}>
+      <AlertDialogTrigger asChild>
+        <Button size="sm" variant="ghost">
+          <Trash2Icon className="h-4 w-4" />
+          {iconOnly ? (
+            <span className="sr-only">delete</span>
+          ) : (
+            <span className="sr-only sm:not-sr-only">delete</span>
+          )}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>delete folder</AlertDialogTitle>
+          <AlertDialogDescription>
+            delete &ldquo;{folderName}&rdquo;? notes inside will not be deleted
+            — they will become unfiled.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isPending}
+            onClick={handleDelete}
+            variant="destructive"
+          >
+            {isPending ? "deleting..." : "delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/folders/folder-panel.tsx
+++ b/src/components/folders/folder-panel.tsx
@@ -17,6 +17,7 @@ import { moveNoteToFolder } from "@/actions/move-note-to-folder";
 import { CreateFolderButton } from "@/components/folders/create-folder-button";
 import { DeleteFolderButton } from "@/components/folders/delete-folder-button";
 import { RenameFolderButton } from "@/components/folders/rename-folder-button";
+import { Button } from "@/components/ui/button";
 import { toFolderId, toNoteId } from "@/lib/id";
 import { parsers } from "@/lib/notes-search-params";
 import { cn } from "@/lib/ui/utils";
@@ -51,10 +52,11 @@ function DropChip({ activeFolder, folder, isDragging }: DropChipProps) {
       )}
       ref={ref}
     >
-      <button
-        className="text-sm font-medium"
+      <Button
+        className="h-auto p-0 text-sm font-medium"
         onClick={handleClick}
         type="button"
+        variant="ghost"
       >
         {folder.name}
         {!isDragging && (
@@ -62,7 +64,7 @@ function DropChip({ activeFolder, folder, isDragging }: DropChipProps) {
             {folder.noteCount}
           </span>
         )}
-      </button>
+      </Button>
       {!isDragging && (
         <div className="ml-1 flex max-w-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[max-width,opacity] duration-150 group-focus-within:max-w-[5rem] group-focus-within:opacity-100 group-hover:max-w-[5rem] group-hover:opacity-100">
           <RenameFolderButton
@@ -94,18 +96,19 @@ function AllChip({ activeFolder }: AllChipProps) {
   };
 
   return (
-    <button
+    <Button
       className={cn(
-        "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+        "h-auto rounded-full px-3 py-1.5 text-sm font-medium",
         isActive
-          ? "border-primary bg-primary/10"
-          : "border-border bg-background hover:border-primary/50",
+          ? "border-primary bg-primary/10 hover:bg-primary/10"
+          : "hover:border-primary/50",
       )}
       onClick={handleClick}
       type="button"
+      variant="outline"
     >
       all
-    </button>
+    </Button>
   );
 }
 

--- a/src/components/folders/folder-panel.tsx
+++ b/src/components/folders/folder-panel.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import {
+  useDragDropMonitor,
+  useDragOperation,
+  useDroppable,
+} from "@dnd-kit/react";
+import { usePathname } from "next/navigation";
+import { useQueryStates } from "nuqs";
+import { useEffect, useState, useTransition } from "react";
+import { createPortal } from "react-dom";
+import { toast } from "sonner";
+
+import type { FolderWithCount } from "@/server/repositories/folder-repository";
+
+import { moveNoteToFolder } from "@/actions/move-note-to-folder";
+import { CreateFolderButton } from "@/components/folders/create-folder-button";
+import { DeleteFolderButton } from "@/components/folders/delete-folder-button";
+import { RenameFolderButton } from "@/components/folders/rename-folder-button";
+import { toFolderId, toNoteId } from "@/lib/id";
+import { parsers } from "@/lib/notes-search-params";
+import { cn } from "@/lib/ui/utils";
+
+interface DropChipProps {
+  activeFolder: string;
+  folder: FolderWithCount;
+  isDragging: boolean;
+}
+
+function DropChip({ activeFolder, folder, isDragging }: DropChipProps) {
+  const folderId = toFolderId(folder.id);
+  const { isDropTarget, ref } = useDroppable({ id: folder.id });
+  const [, setFilters] = useQueryStates(parsers, { shallow: false });
+  const isActive = activeFolder === folder.id;
+
+  const handleClick = async () => {
+    await setFilters({ folder: isActive ? "" : folder.id });
+  };
+
+  return (
+    <div
+      className={cn(
+        "group relative flex items-center rounded-full border px-3 py-1.5 transition-all",
+        isDragging
+          ? isDropTarget
+            ? "scale-105 border-primary bg-primary/10 shadow-md"
+            : "border-border bg-background hover:border-primary/50"
+          : isActive
+            ? "border-primary bg-primary/10"
+            : "border-border bg-background hover:border-primary/50",
+      )}
+      ref={ref}
+    >
+      <button
+        className="text-sm font-medium"
+        onClick={handleClick}
+        type="button"
+      >
+        {folder.name}
+        {!isDragging && (
+          <span className="ml-1.5 text-xs text-muted-foreground">
+            {folder.noteCount}
+          </span>
+        )}
+      </button>
+      {!isDragging && (
+        <div className="ml-1 flex max-w-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[max-width,opacity] duration-150 group-hover:max-w-[5rem] group-hover:opacity-100">
+          <RenameFolderButton
+            currentName={folder.name}
+            folderId={folderId}
+            iconOnly
+          />
+          <DeleteFolderButton
+            folderId={folderId}
+            folderName={folder.name}
+            iconOnly
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AllChipProps {
+  activeFolder: string;
+}
+
+function AllChip({ activeFolder }: AllChipProps) {
+  const [, setFilters] = useQueryStates(parsers, { shallow: false });
+  const isActive = !activeFolder;
+
+  const handleClick = async () => {
+    await setFilters({ folder: "" });
+  };
+
+  return (
+    <button
+      className={cn(
+        "rounded-full border px-3 py-1 text-sm font-medium transition-colors",
+        isActive
+          ? "border-primary bg-primary/10"
+          : "border-border bg-background hover:border-primary/50",
+      )}
+      onClick={handleClick}
+      type="button"
+    >
+      all
+    </button>
+  );
+}
+
+interface FolderPanelProps {
+  folders: FolderWithCount[];
+}
+
+export function FolderPanel({ folders }: FolderPanelProps) {
+  const [filters] = useQueryStates(parsers);
+  const pathname = usePathname();
+  const [, startTransition] = useTransition();
+  const [mounted, setMounted] = useState(false);
+  const { source } = useDragOperation();
+  const isDragging = Boolean(source);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- SSR portal guard
+    setMounted(true);
+  }, []);
+
+  useDragDropMonitor({
+    onDragEnd(event) {
+      if (event.canceled || !event.operation.target) return;
+
+      const noteId = toNoteId(String(event.operation.source?.id ?? ""));
+      const folderId = toFolderId(String(event.operation.target.id));
+
+      startTransition(async () => {
+        try {
+          await moveNoteToFolder(noteId, folderId);
+          toast.success("note moved to folder");
+        } catch {
+          toast.error("failed to move note. please try again.");
+        }
+      });
+    },
+  });
+
+  if (!mounted || (!isDragging && pathname !== "/notes")) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center pb-6">
+      <div className="pointer-events-auto flex flex-wrap items-center justify-center gap-2 rounded-full border bg-background/95 px-4 py-2 shadow-lg backdrop-blur-sm">
+        {!isDragging && <AllChip activeFolder={filters.folder} />}
+        {folders.map((folder) => {
+          return (
+            <DropChip
+              activeFolder={filters.folder}
+              folder={folder}
+              isDragging={isDragging}
+              key={folder.id}
+            />
+          );
+        })}
+        {!isDragging && <CreateFolderButton />}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/folders/folder-panel.tsx
+++ b/src/components/folders/folder-panel.tsx
@@ -96,7 +96,7 @@ function AllChip({ activeFolder }: AllChipProps) {
   return (
     <button
       className={cn(
-        "rounded-full border px-3 py-1 text-sm font-medium transition-colors",
+        "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
         isActive
           ? "border-primary bg-primary/10"
           : "border-border bg-background hover:border-primary/50",
@@ -135,8 +135,12 @@ export function FolderPanel({ folders }: FolderPanelProps) {
 
       if (!sourceId || !targetId) return;
 
+      const targetIdStr = String(targetId);
+
+      if (!folders.some((f) => f.id === targetIdStr)) return;
+
       const noteId = toNoteId(String(sourceId));
-      const folderId = toFolderId(String(targetId));
+      const folderId = toFolderId(targetIdStr);
 
       startTransition(async () => {
         try {

--- a/src/components/folders/folder-panel.tsx
+++ b/src/components/folders/folder-panel.tsx
@@ -64,7 +64,7 @@ function DropChip({ activeFolder, folder, isDragging }: DropChipProps) {
         )}
       </button>
       {!isDragging && (
-        <div className="ml-1 flex max-w-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[max-width,opacity] duration-150 group-hover:max-w-[5rem] group-hover:opacity-100">
+        <div className="ml-1 flex max-w-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[max-width,opacity] duration-150 group-focus-within:max-w-[5rem] group-focus-within:opacity-100 group-hover:max-w-[5rem] group-hover:opacity-100">
           <RenameFolderButton
             currentName={folder.name}
             folderId={folderId}

--- a/src/components/folders/folder-panel.tsx
+++ b/src/components/folders/folder-panel.tsx
@@ -130,8 +130,13 @@ export function FolderPanel({ folders }: FolderPanelProps) {
     onDragEnd(event) {
       if (event.canceled || !event.operation.target) return;
 
-      const noteId = toNoteId(String(event.operation.source?.id ?? ""));
-      const folderId = toFolderId(String(event.operation.target.id));
+      const sourceId = event.operation.source?.id;
+      const targetId = event.operation.target.id;
+
+      if (!sourceId || !targetId) return;
+
+      const noteId = toNoteId(String(sourceId));
+      const folderId = toFolderId(String(targetId));
 
       startTransition(async () => {
         try {

--- a/src/components/folders/rename-folder-button.tsx
+++ b/src/components/folders/rename-folder-button.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { PencilIcon } from "lucide-react";
+import { useRef, useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import type { FolderId } from "@/lib/id";
+
+import { renameFolder } from "@/actions/rename-folder";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+interface RenameFolderButtonProps {
+  currentName: string;
+  folderId: FolderId;
+  iconOnly?: boolean;
+}
+
+export function RenameFolderButton({
+  currentName,
+  folderId,
+  iconOnly = false,
+}: RenameFolderButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }
+
+  function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      try {
+        await renameFolder(formData);
+        setOpen(false);
+        toast.success("folder renamed");
+      } catch {
+        toast.error("failed to rename folder. please try again.");
+      }
+    });
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="ghost">
+          <PencilIcon className="h-4 w-4" />
+          {iconOnly ? (
+            <span className="sr-only">rename</span>
+          ) : (
+            <span className="sr-only sm:not-sr-only">rename</span>
+          )}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>rename folder</DialogTitle>
+        </DialogHeader>
+        <form action={handleSubmit}>
+          <input name="folderId" type="hidden" value={folderId} />
+          <div className="flex flex-col gap-6 py-4">
+            <Field>
+              <FieldLabel htmlFor="folder-name">name</FieldLabel>
+              <Input
+                defaultValue={currentName}
+                id="folder-name"
+                name="name"
+                placeholder="folder name"
+                ref={inputRef}
+                required
+              />
+              <FieldError />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                setOpen(false);
+              }}
+              type="button"
+              variant="outline"
+            >
+              cancel
+            </Button>
+            <Button disabled={isPending} type="submit">
+              {isPending ? "saving..." : "save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/folders/rename-folder-button.tsx
+++ b/src/components/folders/rename-folder-button.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 
 interface RenameFolderButtonProps {
@@ -84,7 +84,6 @@ export function RenameFolderButton({
                 ref={inputRef}
                 required
               />
-              <FieldError />
             </Field>
           </div>
           <DialogFooter>

--- a/src/components/note-drag-drop-provider.tsx
+++ b/src/components/note-drag-drop-provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { AutoScroller, defaultPreset } from "@dnd-kit/dom";
+import { DragDropProvider } from "@dnd-kit/react";
+
+const plugins = defaultPreset.plugins.filter((p) => p !== AutoScroller);
+
+export function NoteDragDropProvider({ children }: { children: ReactNode }) {
+  return <DragDropProvider plugins={plugins}>{children}</DragDropProvider>;
+}

--- a/src/components/notes/active-filters-chip.tsx
+++ b/src/components/notes/active-filters-chip.tsx
@@ -3,18 +3,28 @@
 import { XIcon } from "lucide-react";
 import { useQueryStates } from "nuqs";
 
+import type { FolderWithCount } from "@/server/repositories/folder-repository";
+
 import { Badge } from "@/components/ui/badge";
 import { parsers } from "@/lib/notes-search-params";
 
-interface TagFilterChipProps {
+interface ActiveFiltersChipProps {
+  activeFolder: FolderWithCount | undefined;
   totalCount: number;
 }
 
-export const TagFilterChip = ({ totalCount }: TagFilterChipProps) => {
+export const ActiveFiltersChip = ({
+  activeFolder,
+  totalCount,
+}: ActiveFiltersChipProps) => {
   const [filters, setFilters] = useQueryStates(parsers, { shallow: false });
 
   const clearTag = async () => {
     await setFilters({ tag: "" });
+  };
+
+  const clearFolder = async () => {
+    await setFilters({ folder: "" });
   };
 
   return (
@@ -34,6 +44,22 @@ export const TagFilterChip = ({ totalCount }: TagFilterChipProps) => {
             variant="secondary"
           >
             {filters.tag}
+            <XIcon className="h-3 w-3" />
+          </Badge>
+        </button>
+      )}
+      {filters.folder && activeFolder && (
+        <button
+          aria-label={`clear folder filter: ${activeFolder.name}`}
+          className="flex items-center gap-1"
+          onClick={clearFolder}
+          type="button"
+        >
+          <Badge
+            className="flex items-center gap-1 hover:opacity-80"
+            variant="secondary"
+          >
+            {activeFolder.name}
             <XIcon className="h-3 w-3" />
           </Badge>
         </button>

--- a/src/components/notes/note-card.spec.tsx
+++ b/src/components/notes/note-card.spec.tsx
@@ -17,6 +17,7 @@ const makeNote = (
   return {
     content: overrides.content ?? "Test note content",
     createdAt: overrides.createdAt ?? new Date("2025-06-15"),
+    folderId: null,
     id: overrides.id ?? "note_1",
     pinnedAt: overrides.pinnedAt ?? null,
     remindAt: null,

--- a/src/components/notes/note-card.tsx
+++ b/src/components/notes/note-card.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/react";
 import { BellIcon } from "lucide-react";
 import Link from "next/link";
 
@@ -28,12 +31,17 @@ export const NoteCard = ({
   tags?: SelectTag[];
 }) => {
   const displayContent = truncate(note.content, MAX_CONTENT_LENGTH);
+  const noteId = toNoteId(note.id);
+  const { isDragging, ref } = useDraggable({ id: noteId });
 
   return (
-    <Card className="group relative flex cursor-pointer flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-lg">
+    <Card
+      className={`group relative flex cursor-pointer flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-lg ${isDragging ? "opacity-50" : ""}`}
+      ref={ref}
+    >
       <PinNoteButton
         className="absolute top-2 right-2 z-10"
-        noteId={toNoteId(note.id)}
+        noteId={noteId}
         pinned={Boolean(note.pinnedAt)}
       />
       <CardContent className="flex-1 py-4">

--- a/src/components/notes/note-card.tsx
+++ b/src/components/notes/note-card.tsx
@@ -25,7 +25,7 @@ export const NoteCard = ({
   query,
   tags = EMPTY_TAGS,
 }: {
-  currentParams?: { q?: string; tag?: string; time?: string };
+  currentParams?: { folder?: string; q?: string; tag?: string; time?: string };
   note: SelectNote;
   query?: string;
   tags?: SelectTag[];

--- a/src/components/notes/note-list-item.spec.tsx
+++ b/src/components/notes/note-list-item.spec.tsx
@@ -18,6 +18,7 @@ const makeNote = (
   return {
     content: overrides.content ?? "Test note content",
     createdAt: overrides.createdAt ?? new Date(2025, 5, 15),
+    folderId: null,
     id: overrides.id ?? "note_1",
     pinnedAt: overrides.pinnedAt ?? null,
     remindAt: overrides.remindAt ?? null,

--- a/src/components/notes/note-list-item.tsx
+++ b/src/components/notes/note-list-item.tsx
@@ -24,7 +24,7 @@ export const NoteListItem = ({
   query,
   tags = EMPTY_TAGS,
 }: {
-  currentParams?: { q?: string; tag?: string; time?: string };
+  currentParams?: { folder?: string; q?: string; tag?: string; time?: string };
   note: SelectNote;
   query?: string;
   tags?: SelectTag[];

--- a/src/components/notes/note-list-item.tsx
+++ b/src/components/notes/note-list-item.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useDraggable } from "@dnd-kit/react";
 import { BellIcon } from "lucide-react";
 import Link from "next/link";
 
@@ -27,9 +30,14 @@ export const NoteListItem = ({
   tags?: SelectTag[];
 }) => {
   const displayContent = truncate(note.content, MAX_CONTENT_LENGTH);
+  const noteId = toNoteId(note.id);
+  const { isDragging, ref } = useDraggable({ id: noteId });
 
   return (
-    <div className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted">
+    <div
+      className={`group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted ${isDragging ? "opacity-50" : ""}`}
+      ref={ref}
+    >
       <div className="min-w-0 flex-1">
         <Link
           className="block focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
@@ -64,7 +72,7 @@ export const NoteListItem = ({
           {formatDate(note.createdAt)}
         </span>
         <PinNoteButton
-          noteId={toNoteId(note.id)}
+          noteId={noteId}
           pinned={Boolean(note.pinnedAt)}
           size="icon-xs"
         />

--- a/src/components/notes/note-tags.tsx
+++ b/src/components/notes/note-tags.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 const DEFAULT_MAX_VISIBLE = 3;
 
 interface NoteTagsProps {
-  currentParams?: { q?: string; tag?: string; time?: string };
+  currentParams?: { folder?: string; q?: string; tag?: string; time?: string };
   maxVisible?: number;
   tags: SelectTag[];
 }
@@ -26,6 +26,8 @@ export const NoteTags = ({
     <div className="flex flex-wrap items-center gap-1">
       {visible.map((t) => {
         const params = new URLSearchParams({ tag: t.name });
+
+        if (currentParams?.folder) params.set("folder", currentParams.folder);
 
         if (currentParams?.q) params.set("q", currentParams.q);
 

--- a/src/components/notes/notes.tsx
+++ b/src/components/notes/notes.tsx
@@ -10,7 +10,7 @@ import { NoteCard } from "./note-card";
 import { NoteListItem } from "./note-list-item";
 
 interface NotesListProps {
-  currentParams?: { q?: string; tag?: string; time?: string };
+  currentParams?: { folder?: string; q?: string; tag?: string; time?: string };
   notes: SelectNote[];
   query?: string;
   tagMap?: Record<string, SelectTag[]>;

--- a/src/components/notes/recent-notes.spec.tsx
+++ b/src/components/notes/recent-notes.spec.tsx
@@ -19,6 +19,7 @@ const makeNote = (overrides: { content: string; id: string }) => {
   return {
     content: overrides.content,
     createdAt: new Date("2025-01-01"),
+    folderId: null,
     id: overrides.id,
     pinnedAt: null,
     remindAt: null,

--- a/src/lib/id.ts
+++ b/src/lib/id.ts
@@ -3,12 +3,17 @@ import type { TypeId } from "typeid-js";
 import { typeidUnboxed } from "typeid-js";
 
 export type AssetId = TypeId<"asset">;
+export type FolderId = TypeId<"folder">;
 export type LinkId = TypeId<"link">;
 export type NoteId = TypeId<"note">;
 export type TagId = TypeId<"tag">;
 
 export function generateAssetId() {
   return typeidUnboxed("asset");
+}
+
+export function generateFolderId() {
+  return typeidUnboxed("folder");
 }
 
 export function generateLinkId() {
@@ -26,6 +31,11 @@ export function generateTagId() {
 /** Cast a raw string to AssetId (for route params, FormData, DB results). */
 export function toAssetId(raw: string) {
   return raw as AssetId;
+}
+
+/** Cast a raw string to FolderId (for route params, FormData, DB results). */
+export function toFolderId(raw: string) {
+  return raw as FolderId;
 }
 
 /** Cast a raw string to LinkId (for route params, FormData, DB results). */

--- a/src/lib/notes-search-params.ts
+++ b/src/lib/notes-search-params.ts
@@ -3,6 +3,7 @@ import type { inferParserType } from "nuqs/server";
 import { parseAsString, parseAsStringEnum } from "nuqs/server";
 
 export const parsers = {
+  folder: parseAsString.withDefault(""),
   q: parseAsString.withDefault(""),
   sort: parseAsStringEnum(["newest", "oldest", "updated"]).withDefault(
     "newest",

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -4,6 +4,7 @@ import { drizzle } from "drizzle-orm/libsql";
 import { env } from "@/env";
 
 import * as assets from "./schemas/assets";
+import * as folders from "./schemas/folders";
 import * as links from "./schemas/links";
 import * as notes from "./schemas/notes";
 import * as tags from "./schemas/tags";
@@ -11,6 +12,7 @@ import * as users from "./schemas/users";
 
 const schema = {
   ...users,
+  ...folders,
   ...notes,
   ...assets,
   ...links,

--- a/src/server/db/schemas/folders.ts
+++ b/src/server/db/schemas/folders.ts
@@ -1,0 +1,21 @@
+import { integer, sqliteTable, text, unique } from "drizzle-orm/sqlite-core";
+
+import { user } from "./users";
+
+export const folder = sqliteTable(
+  "folder",
+  {
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (table) => [
+    unique("folder_user_id_name_unique").on(table.userId, table.name),
+  ],
+);
+
+export type SelectFolder = typeof folder.$inferSelect;

--- a/src/server/db/schemas/notes.ts
+++ b/src/server/db/schemas/notes.ts
@@ -1,10 +1,14 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
+import { folder } from "./folders";
 import { user } from "./users";
 
 export const note = sqliteTable("note", {
   content: text("content").notNull(),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  folderId: text("folder_id").references(() => folder.id, {
+    onDelete: "set null",
+  }),
   id: text("id").primaryKey(),
   pinnedAt: integer("pinned_at", { mode: "timestamp" }),
   remindAt: integer("remind_at", { mode: "timestamp" }),

--- a/src/server/repositories/folder-repository.ts
+++ b/src/server/repositories/folder-repository.ts
@@ -1,0 +1,128 @@
+import { and, count, eq } from "drizzle-orm";
+
+import type { FolderId } from "@/lib/id";
+import type { Database } from "@/server/db";
+import type { SelectFolder } from "@/server/db/schemas/folders";
+
+import { folder } from "@/server/db/schemas/folders";
+import { note } from "@/server/db/schemas/notes";
+
+export interface FolderWithCount extends SelectFolder {
+  noteCount: number;
+}
+
+export interface CreateFolderInput {
+  id: FolderId;
+  name: string;
+  userId: string;
+}
+
+export interface UpsertFolderInput {
+  createdAt: Date;
+  id: FolderId;
+  name: string;
+  updatedAt: Date;
+  userId: string;
+}
+
+export interface FolderRepository {
+  create(input: CreateFolderInput): Promise<void>;
+  delete(folderId: FolderId, userId: string): Promise<void>;
+  deleteAllByUserId(userId: string): Promise<void>;
+  findById(
+    folderId: FolderId,
+    userId: string,
+  ): Promise<SelectFolder | undefined>;
+  findByUserId(userId: string): Promise<FolderWithCount[]>;
+  rename(folderId: FolderId, userId: string, name: string): Promise<void>;
+  upsert(input: UpsertFolderInput): Promise<void>;
+}
+
+export class DBFolderRepository implements FolderRepository {
+  constructor(private db: Database) {}
+
+  async create(input: CreateFolderInput): Promise<void> {
+    await this.db.insert(folder).values({
+      createdAt: new Date(),
+      id: input.id,
+      name: input.name,
+      updatedAt: new Date(),
+      userId: input.userId,
+    });
+  }
+
+  async delete(folderId: FolderId, userId: string): Promise<void> {
+    await this.db
+      .delete(folder)
+      .where(and(eq(folder.id, folderId), eq(folder.userId, userId)));
+  }
+
+  async deleteAllByUserId(userId: string): Promise<void> {
+    await this.db.delete(folder).where(eq(folder.userId, userId));
+  }
+
+  async findById(
+    folderId: FolderId,
+    userId: string,
+  ): Promise<SelectFolder | undefined> {
+    const results = await this.db
+      .select()
+      .from(folder)
+      .where(and(eq(folder.id, folderId), eq(folder.userId, userId)))
+      .limit(1);
+
+    return results.length > 0 ? results[0] : undefined;
+  }
+
+  async findByUserId(userId: string): Promise<FolderWithCount[]> {
+    const results = await this.db
+      .select({
+        createdAt: folder.createdAt,
+        id: folder.id,
+        name: folder.name,
+        noteCount: count(note.id),
+        updatedAt: folder.updatedAt,
+        userId: folder.userId,
+      })
+      .from(folder)
+      .leftJoin(
+        note,
+        and(eq(note.folderId, folder.id), eq(note.userId, userId)),
+      )
+      .where(eq(folder.userId, userId))
+      .groupBy(folder.id)
+      .orderBy(folder.name);
+
+    return results;
+  }
+
+  async rename(
+    folderId: FolderId,
+    userId: string,
+    name: string,
+  ): Promise<void> {
+    await this.db
+      .update(folder)
+      .set({ name, updatedAt: new Date() })
+      .where(and(eq(folder.id, folderId), eq(folder.userId, userId)));
+  }
+
+  async upsert(input: UpsertFolderInput): Promise<void> {
+    await this.db
+      .insert(folder)
+      .values({
+        createdAt: input.createdAt,
+        id: input.id,
+        name: input.name,
+        updatedAt: input.updatedAt,
+        userId: input.userId,
+      })
+      .onConflictDoUpdate({
+        set: {
+          name: input.name,
+          updatedAt: input.updatedAt,
+        },
+        target: folder.id,
+      });
+  }
+}

--- a/src/server/repositories/note-repository.ts
+++ b/src/server/repositories/note-repository.ts
@@ -14,7 +14,7 @@ import {
   sql,
 } from "drizzle-orm";
 
-import type { NoteId } from "@/lib/id";
+import type { FolderId, NoteId } from "@/lib/id";
 import type { SortOption, TimeFilter } from "@/lib/utils/note-filters";
 import type { Database } from "@/server/db";
 import type { SelectNote } from "@/server/db/schemas/notes";
@@ -29,6 +29,7 @@ export type PinFilter =
   | { excludePinned?: never; pinnedOnly: true };
 
 export type NoteFilters = PinFilter & {
+  folderId?: FolderId;
   limit?: number;
   query?: string;
   remind?: "overdue" | "upcoming";
@@ -50,6 +51,7 @@ export interface UpdateNoteInput {
 export interface UpsertNoteInput {
   content: string;
   createdAt: Date;
+  folderId?: FolderId | null;
   id: NoteId;
   pinnedAt: Date | null;
   updatedAt: Date;
@@ -67,6 +69,11 @@ export interface NoteRepository {
   findById(noteId: NoteId, userId: string): Promise<SelectNote | undefined>;
   findDueReminders(userId: string): Promise<SelectNote[]>;
   findMany(userId: string, filters: NoteFilters): Promise<SelectNote[]>;
+  moveToFolder(
+    noteId: NoteId,
+    userId: string,
+    folderId: FolderId | null,
+  ): Promise<void>;
   pin(noteId: NoteId, userId: string): Promise<void>;
   setReminder(noteId: NoteId, userId: string, remindAt: Date): Promise<void>;
   unpin(noteId: NoteId, userId: string): Promise<void>;
@@ -217,12 +224,17 @@ export class DBNoteRepository implements NoteRepository {
           ? [isNotNull(note.remindAt), gt(note.remindAt, new Date())]
           : [];
 
+    const folderFilter = filters.folderId
+      ? [eq(note.folderId, filters.folderId)]
+      : [];
+
     const whereClause = and(
       ...baseFilters,
       ...pinnedFilter,
       ...queryFilter,
       ...timeFilter,
       ...remindFilter,
+      ...folderFilter,
     );
 
     const orderBy = getSortOrder(filters.sort);
@@ -233,6 +245,7 @@ export class DBNoteRepository implements NoteRepository {
         .selectDistinct({
           content: note.content,
           createdAt: note.createdAt,
+          folderId: note.folderId,
           id: note.id,
           pinnedAt: note.pinnedAt,
           remindAt: note.remindAt,
@@ -264,6 +277,17 @@ export class DBNoteRepository implements NoteRepository {
     }
 
     return qb;
+  }
+
+  async moveToFolder(
+    noteId: NoteId,
+    userId: string,
+    folderId: FolderId | null,
+  ): Promise<void> {
+    await this.db
+      .update(note)
+      .set({ folderId, updatedAt: new Date() })
+      .where(and(eq(note.id, noteId), eq(note.userId, userId)));
   }
 
   async pin(noteId: NoteId, userId: string): Promise<void> {
@@ -319,6 +343,7 @@ export class DBNoteRepository implements NoteRepository {
       .values({
         content: input.content,
         createdAt: input.createdAt,
+        folderId: input.folderId ?? null,
         id: input.id,
         pinnedAt: input.pinnedAt,
         updatedAt: input.updatedAt,
@@ -327,6 +352,7 @@ export class DBNoteRepository implements NoteRepository {
       .onConflictDoUpdate({
         set: {
           content: input.content,
+          folderId: input.folderId ?? null,
           pinnedAt: input.pinnedAt,
           updatedAt: input.updatedAt,
         },

--- a/src/server/schemas/export-schemas.ts
+++ b/src/server/schemas/export-schemas.ts
@@ -2,10 +2,12 @@ import { z } from "zod";
 
 const NOTE_ID_PATTERN = /^note_[\da-hjkmnp-tv-z]{26}$/;
 const ASSET_ID_PATTERN = /^asset_[\da-hjkmnp-tv-z]{26}$/;
+const FOLDER_ID_PATTERN = /^folder_[\da-hjkmnp-tv-z]{26}$/;
 
 export const manifestSchema = z.object({
   assetCount: z.number().int().nonnegative(),
   exportedAt: z.iso.datetime(),
+  folderCount: z.number().int().nonnegative().optional(),
   noteCount: z.number().int().nonnegative(),
   version: z.literal(1),
 });
@@ -21,10 +23,22 @@ export const exportedAssetSchema = z.object({
   width: z.number().int().nonnegative(),
 });
 
+export const exportedFolderSchema = z.object({
+  createdAt: z.iso.datetime(),
+  id: z.string().regex(FOLDER_ID_PATTERN, "Invalid folder ID format"),
+  name: z.string().min(1),
+  updatedAt: z.iso.datetime(),
+});
+
 export const exportedNoteSchema = z.object({
   assets: z.array(exportedAssetSchema),
   content: z.string().min(1),
   createdAt: z.iso.datetime(),
+  folderId: z
+    .string()
+    .regex(FOLDER_ID_PATTERN, "Invalid folder ID format")
+    .nullable()
+    .optional(),
   id: z.string().regex(NOTE_ID_PATTERN, "Invalid note ID format"),
   pinnedAt: z.iso.datetime().nullable(),
   tags: z.array(z.string()).optional(),
@@ -32,6 +46,8 @@ export const exportedNoteSchema = z.object({
 });
 
 export const exportDataSchema = z.array(exportedNoteSchema);
+
+export const exportFolderDataSchema = z.array(exportedFolderSchema);
 
 export const importModeSchema = z.enum(["merge", "mirror"]);
 
@@ -43,6 +59,7 @@ export const importInputSchema = z.object({
 });
 
 export type ExportedAsset = z.infer<typeof exportedAssetSchema>;
+export type ExportedFolder = z.infer<typeof exportedFolderSchema>;
 export type ExportedNote = z.infer<typeof exportedNoteSchema>;
 export type ImportMode = z.infer<typeof importModeSchema>;
 export type Manifest = z.infer<typeof manifestSchema>;

--- a/src/server/schemas/folder-schemas.ts
+++ b/src/server/schemas/folder-schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createFolderSchema = z.object({
+  name: z.string().min(1, "name is required").max(100, "name is too long"),
+});
+
+export const renameFolderSchema = z.object({
+  folderId: z.string().min(1, "folder id is required"),
+  name: z.string().min(1, "name is required").max(100, "name is too long"),
+});

--- a/src/server/schemas/folder-schemas.ts
+++ b/src/server/schemas/folder-schemas.ts
@@ -1,10 +1,18 @@
 import { z } from "zod";
 
 export const createFolderSchema = z.object({
-  name: z.string().min(1, "name is required").max(100, "name is too long"),
+  name: z
+    .string()
+    .trim()
+    .min(1, "name is required")
+    .max(100, "name is too long"),
 });
 
 export const renameFolderSchema = z.object({
   folderId: z.string().min(1, "folder id is required"),
-  name: z.string().min(1, "name is required").max(100, "name is too long"),
+  name: z
+    .string()
+    .trim()
+    .min(1, "name is required")
+    .max(100, "name is too long"),
 });

--- a/src/server/services/export-service.ts
+++ b/src/server/services/export-service.ts
@@ -4,16 +4,19 @@ import { zipSync } from "fflate";
 
 import type { NoteId } from "@/lib/id";
 import type { AssetRepository } from "@/server/repositories/asset-repository";
+import type { FolderRepository } from "@/server/repositories/folder-repository";
 import type { NoteRepository } from "@/server/repositories/note-repository";
 import type { TagRepository } from "@/server/repositories/tag-repository";
 import type {
   ExportedAsset,
+  ExportedFolder,
   ExportedNote,
   Manifest,
 } from "@/server/schemas/export-schemas";
 
 import { getDb } from "@/server/db";
 import { DBAssetRepository } from "@/server/repositories/asset-repository";
+import { DBFolderRepository } from "@/server/repositories/folder-repository";
 import { DBNoteRepository } from "@/server/repositories/note-repository";
 import { DBTagRepository } from "@/server/repositories/tag-repository";
 
@@ -26,10 +29,14 @@ class ExportService {
     private noteRepo: NoteRepository,
     private assetRepo: AssetRepository,
     private tagRepo: TagRepository,
+    private folderRepo: FolderRepository,
   ) {}
 
   async exportAll(userId: string): Promise<Uint8Array> {
-    const notes = await this.noteRepo.findMany(userId, {});
+    const [notes, foldersWithCount] = await Promise.all([
+      this.noteRepo.findMany(userId, {}),
+      this.folderRepo.findByUserId(userId),
+    ]);
 
     const noteIds = notes.map((n) => n.id as NoteId);
     const tagMap = await this.tagRepo.findByNoteIds(noteIds, userId);
@@ -71,6 +78,7 @@ class ExportService {
         assets: exportedAssets,
         content: n.content,
         createdAt: n.createdAt.toISOString(),
+        folderId: n.folderId ?? null,
         id: n.id,
         pinnedAt: n.pinnedAt?.toISOString() ?? null,
         tags: noteTags.map((t) => t.name),
@@ -78,9 +86,19 @@ class ExportService {
       });
     }
 
+    const exportedFolders: ExportedFolder[] = foldersWithCount.map((f) => {
+      return {
+        createdAt: f.createdAt.toISOString(),
+        id: f.id,
+        name: f.name,
+        updatedAt: f.updatedAt.toISOString(),
+      };
+    });
+
     const manifest: Manifest = {
       assetCount,
       exportedAt: new Date().toISOString(),
+      folderCount: exportedFolders.length,
       noteCount: exportedNotes.length,
       version: 1,
     };
@@ -88,6 +106,7 @@ class ExportService {
     const encoder = new TextEncoder();
 
     const zipData: Record<string, Uint8Array> = {
+      "folders.json": encoder.encode(JSON.stringify(exportedFolders, null, 2)),
       "manifest.json": encoder.encode(JSON.stringify(manifest, null, 2)),
       "notes.json": encoder.encode(JSON.stringify(exportedNotes, null, 2)),
       ...assetFiles,
@@ -104,6 +123,7 @@ export function getExportService() {
     new DBNoteRepository(getDb()),
     new DBAssetRepository(getDb()),
     new DBTagRepository(getDb()),
+    new DBFolderRepository(getDb()),
   );
 
   return _exportService;

--- a/src/server/services/folder-service.ts
+++ b/src/server/services/folder-service.ts
@@ -1,0 +1,70 @@
+import type { FolderId, NoteId } from "@/lib/id";
+import type { SelectFolder } from "@/server/db/schemas/folders";
+import type {
+  FolderRepository,
+  FolderWithCount,
+} from "@/server/repositories/folder-repository";
+import type { NoteRepository } from "@/server/repositories/note-repository";
+
+import { generateFolderId } from "@/lib/id";
+import { getDb } from "@/server/db";
+import { DBFolderRepository } from "@/server/repositories/folder-repository";
+import { DBNoteRepository } from "@/server/repositories/note-repository";
+
+class FolderService {
+  constructor(
+    private folderRepo: FolderRepository,
+    private noteRepo: NoteRepository,
+    private idGenerator: () => FolderId = generateFolderId,
+  ) {}
+
+  async create(userId: string, name: string): Promise<FolderId> {
+    const id = this.idGenerator();
+
+    await this.folderRepo.create({ id, name, userId });
+
+    return id;
+  }
+
+  async delete(userId: string, folderId: FolderId): Promise<void> {
+    await this.folderRepo.delete(folderId, userId);
+  }
+
+  async getAll(userId: string): Promise<FolderWithCount[]> {
+    return this.folderRepo.findByUserId(userId);
+  }
+
+  async getById(
+    userId: string,
+    folderId: FolderId,
+  ): Promise<SelectFolder | undefined> {
+    return this.folderRepo.findById(folderId, userId);
+  }
+
+  async move(
+    userId: string,
+    noteId: NoteId,
+    folderId: FolderId | null,
+  ): Promise<void> {
+    await this.noteRepo.moveToFolder(noteId, userId, folderId);
+  }
+
+  async rename(
+    userId: string,
+    folderId: FolderId,
+    name: string,
+  ): Promise<void> {
+    await this.folderRepo.rename(folderId, userId, name);
+  }
+}
+
+let _folderService: FolderService | undefined;
+
+export function getFolderService() {
+  _folderService ??= new FolderService(
+    new DBFolderRepository(getDb()),
+    new DBNoteRepository(getDb()),
+  );
+
+  return _folderService;
+}

--- a/src/server/services/import-service.ts
+++ b/src/server/services/import-service.ts
@@ -128,9 +128,9 @@ class ImportService {
       };
     }
 
-    // Restore folders first so that note folderId FKs resolve.
     const foldersRaw = files["folders.json"] as Uint8Array | undefined;
     const importedFolderIds = new Set<string>();
+    const foldersImported = Boolean(foldersRaw);
 
     if (foldersRaw) {
       const foldersResult = exportFolderDataSchema.safeParse(
@@ -195,7 +195,6 @@ class ImportService {
 
       const formattedContent = await formatMarkdown(exportedNote.content);
 
-      // Only assign folderId if the folder was actually imported/exists.
       const folderId: FolderId | null =
         exportedNote.folderId && importedFolderIds.has(exportedNote.folderId)
           ? toFolderId(exportedNote.folderId)
@@ -247,14 +246,15 @@ class ImportService {
 
       await this.tagRepo.deleteOrphanedTags(userId);
 
-      // In mirror mode, delete folders not present in the import.
-      const allLocalFolders = await this.folderRepo.findByUserId(userId);
-      const toDeleteFolders = allLocalFolders.filter(
-        (f) => !importedFolderIds.has(f.id),
-      );
+      if (foldersImported) {
+        const allLocalFolders = await this.folderRepo.findByUserId(userId);
+        const toDeleteFolders = allLocalFolders.filter(
+          (f) => !importedFolderIds.has(f.id),
+        );
 
-      for (const f of toDeleteFolders) {
-        await this.folderRepo.delete(toFolderId(f.id), userId);
+        for (const f of toDeleteFolders) {
+          await this.folderRepo.delete(toFolderId(f.id), userId);
+        }
       }
     }
 

--- a/src/server/services/import-service.ts
+++ b/src/server/services/import-service.ts
@@ -2,22 +2,25 @@ import { TextDecoder } from "node:util";
 
 import { unzipSync } from "fflate";
 
-import type { NoteId } from "@/lib/id";
+import type { FolderId, NoteId } from "@/lib/id";
 import type {
   AssetRepository,
   CreateAssetInput,
 } from "@/server/repositories/asset-repository";
+import type { FolderRepository } from "@/server/repositories/folder-repository";
 import type { NoteRepository } from "@/server/repositories/note-repository";
 import type { TagRepository } from "@/server/repositories/tag-repository";
 import type { ExportedNote, ImportMode } from "@/server/schemas/export-schemas";
 
-import { toAssetId, toNoteId } from "@/lib/id";
+import { toAssetId, toFolderId, toNoteId } from "@/lib/id";
 import { getDb } from "@/server/db";
 import { DBAssetRepository } from "@/server/repositories/asset-repository";
+import { DBFolderRepository } from "@/server/repositories/folder-repository";
 import { DBNoteRepository } from "@/server/repositories/note-repository";
 import { DBTagRepository } from "@/server/repositories/tag-repository";
 import {
   exportDataSchema,
+  exportFolderDataSchema,
   manifestSchema,
 } from "@/server/schemas/export-schemas";
 import { formatMarkdown } from "@/server/services/format-service";
@@ -95,6 +98,7 @@ class ImportService {
     private noteRepo: NoteRepository,
     private assetRepo: AssetRepository,
     private tagRepo: TagRepository,
+    private folderRepo: FolderRepository,
   ) {}
 
   async importZip(
@@ -122,6 +126,30 @@ class ImportService {
         ...FAIL_RESULT,
         message: "invalid export file: invalid manifest format",
       };
+    }
+
+    // Restore folders first so that note folderId FKs resolve.
+    const foldersRaw = files["folders.json"] as Uint8Array | undefined;
+    const importedFolderIds = new Set<string>();
+
+    if (foldersRaw) {
+      const foldersResult = exportFolderDataSchema.safeParse(
+        JSON.parse(decoder.decode(foldersRaw)),
+      );
+
+      if (foldersResult.success) {
+        for (const f of foldersResult.data) {
+          await this.folderRepo.upsert({
+            createdAt: new Date(f.createdAt),
+            id: toFolderId(f.id),
+            name: f.name,
+            updatedAt: new Date(f.updatedAt),
+            userId,
+          });
+
+          importedFolderIds.add(f.id);
+        }
+      }
     }
 
     const notesRaw = files["notes.json"] as Uint8Array | undefined;
@@ -167,9 +195,16 @@ class ImportService {
 
       const formattedContent = await formatMarkdown(exportedNote.content);
 
+      // Only assign folderId if the folder was actually imported/exists.
+      const folderId =
+        exportedNote.folderId && importedFolderIds.has(exportedNote.folderId)
+          ? toFolderId(exportedNote.folderId)
+          : (null as FolderId | null);
+
       await this.noteRepo.upsert({
         content: formattedContent,
         createdAt: new Date(exportedNote.createdAt),
+        folderId,
         id: noteId,
         pinnedAt: exportedNote.pinnedAt
           ? new Date(exportedNote.pinnedAt)
@@ -211,6 +246,16 @@ class ImportService {
       }
 
       await this.tagRepo.deleteOrphanedTags(userId);
+
+      // In mirror mode, delete folders not present in the import.
+      const allLocalFolders = await this.folderRepo.findByUserId(userId);
+      const toDeleteFolders = allLocalFolders.filter(
+        (f) => !importedFolderIds.has(f.id),
+      );
+
+      for (const f of toDeleteFolders) {
+        await this.folderRepo.delete(toFolderId(f.id), userId);
+      }
     }
 
     await this.noteRepo.updateSyncedAt(importedNoteIds, userId);
@@ -233,6 +278,7 @@ export function getImportService() {
     new DBNoteRepository(getDb()),
     new DBAssetRepository(getDb()),
     new DBTagRepository(getDb()),
+    new DBFolderRepository(getDb()),
   );
 
   return _importService;

--- a/src/server/services/import-service.ts
+++ b/src/server/services/import-service.ts
@@ -196,10 +196,10 @@ class ImportService {
       const formattedContent = await formatMarkdown(exportedNote.content);
 
       // Only assign folderId if the folder was actually imported/exists.
-      const folderId =
+      const folderId: FolderId | null =
         exportedNote.folderId && importedFolderIds.has(exportedNote.folderId)
           ? toFolderId(exportedNote.folderId)
-          : (null as FolderId | null);
+          : null;
 
       await this.noteRepo.upsert({
         content: formattedContent,

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -2,6 +2,7 @@ import type { RenderOptions } from "@testing-library/react";
 import type { ReactElement } from "react";
 import type * as React from "react";
 
+import { DragDropProvider } from "@dnd-kit/react";
 import { render } from "@testing-library/react";
 import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 
@@ -17,10 +18,12 @@ interface AllProvidersProps {
 const AllTheProviders = ({ children, searchParams }: AllProvidersProps) => {
   return (
     <NuqsTestingAdapter searchParams={searchParams}>
-      <TooltipProvider>
-        <Toaster />
-        {children}
-      </TooltipProvider>
+      <DragDropProvider>
+        <TooltipProvider>
+          <Toaster />
+          {children}
+        </TooltipProvider>
+      </DragDropProvider>
     </NuqsTestingAdapter>
   );
 };


### PR DESCRIPTION
## Summary

- Replaces the `/folders` nav route and full-screen `FolderDropZone` overlay with a persistent floating `FolderPanel` pill fixed at the bottom center of `/notes`; always visible (even with 0 folders), hidden on all other pages unless a drag is in progress
- `FolderPanel` acts as both a filter surface (click a chip to filter notes by folder) and a drag-and-drop target (drop a note card onto a folder chip to move it); folders are passed server-side from `layout.tsx` to avoid the async load delay the old overlay had
- Adds the full folder data layer: SQLite schema, `FolderRepository`, `FolderService`, and server actions for create, delete, rename, move note to folder, and get folders
- Adds `NoteDragDropProvider` wrapping `@dnd-kit/react` with `AutoScroller` disabled (prevents aggressive page scroll near the bottom where the panel lives)
- Replaces `TagFilterChip` with `ActiveFiltersChip` that handles both tag and folder dismissible filter chips in a single component
- Extends export/import to include folders and note-folder assignments
- Updates `AGENTS.md` and `README.md` to document the folder panel, tagging, and `cn()` convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tags: view/manage tags on notes; tag badges filter by tag; inline tag create/delete.
  * Folders: create, rename, delete; folder panel on the notes page with per-folder counts and active-folder display.
  * Drag & drop: move notes between folders via drag-and-drop; folder-aware dragging in note lists/cards.

* **Filters & Export/Import**
  * Active, clearable filters showing tag and folder filters.
  * Folders included in export/import.

* **UX**
  * Form hotkeys (Mod+Enter submit, Esc cancel) and consistent field/button layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->