### PR TITLE
fix: 🐛 consistent card heights when notes have no tags

### DIFF
--- a/src/components/notes/note-card.tsx
+++ b/src/components/notes/note-card.tsx
@@ -72,9 +72,7 @@ export const NoteCard = ({
           {formatDate(note.createdAt)}
           {note.remindAt && <BellIcon className="h-3 w-3" />}
         </span>
-        {tags.length > 0 && (
-          <NoteTags currentParams={currentParams} tags={tags} />
-        )}
+        <NoteTags currentParams={currentParams} tags={tags} />
       </CardFooter>
     </Card>
   );

--- a/src/components/notes/note-tags.tsx
+++ b/src/components/notes/note-tags.tsx
@@ -17,7 +17,7 @@ export const NoteTags = ({
   maxVisible = DEFAULT_MAX_VISIBLE,
   tags,
 }: NoteTagsProps) => {
-  if (tags.length === 0) return null;
+  if (tags.length === 0) return <div className="h-5" />;
 
   const visible = tags.slice(0, maxVisible);
   const overflow = tags.length - visible.length;


### PR DESCRIPTION
## Summary

- Cards without tags were shorter than cards with tags because the tag row was conditionally rendered
- `NoteTags` now returns a `<div className="h-5" />` placeholder instead of `null` when there are no tags, reserving the same vertical space as a badge row
- Removed the `tags.length > 0` guard in `NoteCard` so `NoteTags` is always rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout consistency for note cards. Fixed spacing behavior when tags are absent to prevent unexpected layout shifts. The component now maintains uniform visual appearance across all notes, ensuring consistent spacing and alignment regardless of whether tags are present, enhancing the overall visual polish of the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->