### PR TITLE
feat: ✨ extract first line as note title in list views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ data/*.db*
 # eslint
 .eslintcache
 
+# worktrees
+/.worktrees
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ If any step fails, fix the issue and re-run from that step. Do not move on until
 - **Bottom-up file structure:** Files should read bottom-up -- private/helper components and functions at the top, the main exported component at the bottom. This way the file's public API is immediately visible when you scroll to the end.
 - **Lowercase aesthetic:** All user-facing text in the UI is lowercase -- labels, button text, headings, placeholder text, toast messages, tooltips, etc. This is a deliberate design choice across the entire app, not just forms.
 - **Date formatting:** All date display in components goes through `formatDate` (date only) and `formatDateTime` (date + time) from `@/lib/utils/format.ts`. Both return lowercase output to match the app's aesthetic. Do not use raw `format()` from `date-fns` directly in components.
-- **Note preview / title extraction:** Notes have no title field. In list views, use `extractNoteTitle(content)` from `@/lib/utils/extract-note-title` to derive a display title. It takes the first non-empty line, strips markdown syntax via `stripMarkdown` (`@/lib/utils/strip-markdown`), and truncates to 80 characters at a word boundary. Do not slice `content` directly in components.
+- **Note preview / title extraction:** Notes have no title field. In list views, use `extractNoteTitle(content)` from `@/lib/utils/extract-note-title` to derive a display title. It takes the first non-empty line, strips Markdown syntax via `stripMarkdown` (`@/lib/utils/strip-markdown`), and truncates to 80 characters at a word boundary. Do not slice `content` directly in components.
 
 ### Lint-enforced
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ If any step fails, fix the issue and re-run from that step. Do not move on until
 - **Bottom-up file structure:** Files should read bottom-up -- private/helper components and functions at the top, the main exported component at the bottom. This way the file's public API is immediately visible when you scroll to the end.
 - **Lowercase aesthetic:** All user-facing text in the UI is lowercase -- labels, button text, headings, placeholder text, toast messages, tooltips, etc. This is a deliberate design choice across the entire app, not just forms.
 - **Date formatting:** All date display in components goes through `formatDate` (date only) and `formatDateTime` (date + time) from `@/lib/utils/format.ts`. Both return lowercase output to match the app's aesthetic. Do not use raw `format()` from `date-fns` directly in components.
+- **Note preview / title extraction:** Notes have no title field. In list views, use `extractNoteTitle(content)` from `@/lib/utils/extract-note-title` to derive a display title. It takes the first non-empty line, strips markdown syntax via `stripMarkdown` (`@/lib/utils/strip-markdown`), and truncates to 80 characters at a word boundary. Do not slice `content` directly in components.
 
 ### Lint-enforced
 

--- a/src/components/notes/note-list-item.spec.tsx
+++ b/src/components/notes/note-list-item.spec.tsx
@@ -46,12 +46,12 @@ describe("NoteListItem", () => {
     expect(screen.getByText("Buy groceries")).toBeInTheDocument();
   });
 
-  it("should truncate content longer than 200 characters", () => {
-    const longContent = "x".repeat(250);
+  it("should truncate content longer than 80 characters", () => {
+    const longContent = "x".repeat(100);
 
     render(<NoteListItem note={makeNote({ content: longContent })} />);
 
-    expect(screen.getByText(`${"x".repeat(200)}...`)).toBeInTheDocument();
+    expect(screen.getByText(`${"x".repeat(80)}...`)).toBeInTheDocument();
   });
 
   it("should display the formatted creation date", () => {

--- a/src/components/notes/note-list-item.tsx
+++ b/src/components/notes/note-list-item.tsx
@@ -9,14 +9,13 @@ import type { NoteWithFolder } from "@/server/repositories/note-repository";
 
 import { toNoteId } from "@/lib/id";
 import { cn } from "@/lib/ui/utils";
+import { extractNoteTitle } from "@/lib/utils/extract-note-title";
 import { formatDate } from "@/lib/utils/format";
 import { getHighlightedParts } from "@/lib/utils/highlight";
-import { truncate } from "@/lib/utils/truncate";
 
 import { NoteTags } from "./note-tags";
 import { PinNoteButton } from "./pin-note-button";
 
-const MAX_CONTENT_LENGTH = 200;
 const EMPTY_TAGS: SelectTag[] = [];
 
 export const NoteListItem = ({
@@ -32,7 +31,7 @@ export const NoteListItem = ({
   query?: string;
   tags?: SelectTag[];
 }) => {
-  const displayContent = truncate(note.content, MAX_CONTENT_LENGTH);
+  const displayContent = extractNoteTitle(note.content);
   const noteId = toNoteId(note.id);
   const { handleRef, isDragging, ref } = useDraggable({ id: noteId });
 

--- a/src/components/notes/recent-notes.tsx
+++ b/src/components/notes/recent-notes.tsx
@@ -4,11 +4,9 @@ import type { SelectNote } from "@/server/db/schemas/notes";
 
 import { Kbd } from "@/components/ui/kbd";
 import { Separator } from "@/components/ui/separator";
-import { truncate } from "@/lib/utils/truncate";
+import { extractNoteTitle } from "@/lib/utils/extract-note-title";
 
 import { AnimatedListItem } from "./animated-list-item";
-
-const MAX_CONTENT_LENGTH = 80;
 
 export function RecentNotes({ notes }: { notes: SelectNote[] }) {
   if (notes.length === 0) return null;
@@ -27,7 +25,7 @@ export function RecentNotes({ notes }: { notes: SelectNote[] }) {
                 className="block truncate py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
                 href={`/notes/${n.id}`}
               >
-                {truncate(n.content, MAX_CONTENT_LENGTH)}
+                {extractNoteTitle(n.content)}
               </Link>
             </AnimatedListItem>
           );

--- a/src/lib/utils/extract-note-title.spec.ts
+++ b/src/lib/utils/extract-note-title.spec.ts
@@ -1,0 +1,51 @@
+import { extractNoteTitle } from "./extract-note-title";
+
+describe("extractNoteTitle", () => {
+  it("should return a plain single-line note as-is", () => {
+    expect(extractNoteTitle("just a plain note")).toBe("just a plain note");
+  });
+
+  it("should return the first line of a multi-line note", () => {
+    expect(extractNoteTitle("first line\nsecond line\nthird line")).toBe(
+      "first line",
+    );
+  });
+
+  it("should skip blank leading lines and use the first non-empty line", () => {
+    expect(extractNoteTitle("\n\nactual content\nmore content")).toBe(
+      "actual content",
+    );
+  });
+
+  it("should strip markdown heading from the first line", () => {
+    expect(extractNoteTitle("# My note title\nsome body text")).toBe(
+      "My note title",
+    );
+  });
+
+  it("should strip bold markdown from the first line", () => {
+    expect(extractNoteTitle("**important note**\nbody")).toBe("important note");
+  });
+
+  it("should strip inline code from the first line", () => {
+    expect(extractNoteTitle("`code title`\nbody")).toBe("code title");
+  });
+
+  it("should truncate a very long first line at a word boundary", () => {
+    const longLine =
+      "this is a very long first line that goes well beyond eighty characters in total length";
+    const result = extractNoteTitle(longLine);
+
+    expect(result.endsWith("...")).toBe(true);
+    // 80 chars + "..."
+    expect(result.length).toBeLessThanOrEqual(83);
+  });
+
+  it("should handle an empty string", () => {
+    expect(extractNoteTitle("")).toBe("");
+  });
+
+  it("should handle a note with only whitespace on the first line", () => {
+    expect(extractNoteTitle("   \nreal content")).toBe("real content");
+  });
+});

--- a/src/lib/utils/extract-note-title.spec.ts
+++ b/src/lib/utils/extract-note-title.spec.ts
@@ -37,12 +37,15 @@ describe("extractNoteTitle", () => {
     const result = extractNoteTitle(longLine);
 
     expect(result.endsWith("...")).toBe(true);
-    // 80 chars + "..."
     expect(result.length).toBeLessThanOrEqual(83);
   });
 
   it("should handle an empty string", () => {
     expect(extractNoteTitle("")).toBe("");
+  });
+
+  it("should skip lines that are empty after stripping markdown", () => {
+    expect(extractNoteTitle("# \n## \nactual content")).toBe("actual content");
   });
 
   it("should handle a note with only whitespace on the first line", () => {

--- a/src/lib/utils/extract-note-title.ts
+++ b/src/lib/utils/extract-note-title.ts
@@ -1,0 +1,11 @@
+import { stripMarkdown } from "./strip-markdown";
+import { truncate } from "./truncate";
+
+const MAX_TITLE_LENGTH = 80;
+
+export const extractNoteTitle = (content: string): string => {
+  const firstLine =
+    content.split("\n").find((line) => line.trim().length > 0) ?? content;
+
+  return truncate(stripMarkdown(firstLine), MAX_TITLE_LENGTH);
+};

--- a/src/lib/utils/extract-note-title.ts
+++ b/src/lib/utils/extract-note-title.ts
@@ -4,8 +4,11 @@ import { truncate } from "./truncate";
 const MAX_TITLE_LENGTH = 80;
 
 export const extractNoteTitle = (content: string): string => {
-  const firstLine =
-    content.split("\n").find((line) => line.trim().length > 0) ?? content;
+  const stripped =
+    content
+      .split("\n")
+      .map((line) => stripMarkdown(line))
+      .find((line) => line.trim().length > 0) ?? stripMarkdown(content);
 
-  return truncate(stripMarkdown(firstLine), MAX_TITLE_LENGTH);
+  return truncate(stripped, MAX_TITLE_LENGTH);
 };

--- a/src/lib/utils/strip-markdown.spec.ts
+++ b/src/lib/utils/strip-markdown.spec.ts
@@ -1,0 +1,76 @@
+import { stripMarkdown } from "./strip-markdown";
+
+describe("stripMarkdown", () => {
+  it("should return plain text unchanged", () => {
+    expect(stripMarkdown("hello world")).toBe("hello world");
+  });
+
+  it("should strip heading markers", () => {
+    expect(stripMarkdown("# Heading one")).toBe("Heading one");
+    expect(stripMarkdown("## Heading two")).toBe("Heading two");
+    expect(stripMarkdown("### Heading three")).toBe("Heading three");
+  });
+
+  it("should strip blockquote markers", () => {
+    expect(stripMarkdown("> quoted text")).toBe("quoted text");
+  });
+
+  it("should strip unordered list markers", () => {
+    expect(stripMarkdown("- list item")).toBe("list item");
+    expect(stripMarkdown("* list item")).toBe("list item");
+  });
+
+  it("should strip ordered list markers", () => {
+    expect(stripMarkdown("1. first item")).toBe("first item");
+    expect(stripMarkdown("42. some item")).toBe("some item");
+  });
+
+  it("should strip bold syntax", () => {
+    expect(stripMarkdown("**bold text**")).toBe("bold text");
+    expect(stripMarkdown("__bold text__")).toBe("bold text");
+  });
+
+  it("should strip italic syntax", () => {
+    expect(stripMarkdown("*italic text*")).toBe("italic text");
+    expect(stripMarkdown("_italic text_")).toBe("italic text");
+  });
+
+  it("should strip bold+italic syntax", () => {
+    expect(stripMarkdown("***bold italic***")).toBe("bold italic");
+    expect(stripMarkdown("___bold italic___")).toBe("bold italic");
+  });
+
+  it("should strip strikethrough syntax", () => {
+    expect(stripMarkdown("~~struck through~~")).toBe("struck through");
+  });
+
+  it("should strip inline code", () => {
+    expect(stripMarkdown("`some code`")).toBe("some code");
+  });
+
+  it("should collapse link syntax to text", () => {
+    expect(stripMarkdown("[link text](https://example.com)")).toBe("link text");
+  });
+
+  it("should collapse image syntax to alt text", () => {
+    expect(stripMarkdown("![alt text](https://example.com/img.png)")).toBe(
+      "alt text",
+    );
+  });
+
+  it("should strip horizontal rules", () => {
+    expect(stripMarkdown("---")).toBe("");
+    expect(stripMarkdown("***")).toBe("");
+    expect(stripMarkdown("___")).toBe("");
+  });
+
+  it("should handle mixed inline syntax", () => {
+    expect(stripMarkdown("**bold** and *italic* and `code`")).toBe(
+      "bold and italic and code",
+    );
+  });
+
+  it("should collapse extra whitespace", () => {
+    expect(stripMarkdown("  too   many   spaces  ")).toBe("too many spaces");
+  });
+});

--- a/src/lib/utils/strip-markdown.spec.ts
+++ b/src/lib/utils/strip-markdown.spec.ts
@@ -11,6 +11,12 @@ describe("stripMarkdown", () => {
     expect(stripMarkdown("### Heading three")).toBe("Heading three");
   });
 
+  it("should return empty string for marker-only headings", () => {
+    expect(stripMarkdown("#   ")).toBe("");
+    expect(stripMarkdown("## ")).toBe("");
+    expect(stripMarkdown("###    ")).toBe("");
+  });
+
   it("should strip blockquote markers", () => {
     expect(stripMarkdown("> quoted text")).toBe("quoted text");
   });

--- a/src/lib/utils/strip-markdown.spec.ts
+++ b/src/lib/utils/strip-markdown.spec.ts
@@ -35,6 +35,11 @@ describe("stripMarkdown", () => {
     expect(stripMarkdown("_italic text_")).toBe("italic text");
   });
 
+  it("should not strip underscores inside word identifiers", () => {
+    expect(stripMarkdown("foo_bar_baz")).toBe("foo_bar_baz");
+    expect(stripMarkdown("some_variable_name")).toBe("some_variable_name");
+  });
+
   it("should strip bold+italic syntax", () => {
     expect(stripMarkdown("***bold italic***")).toBe("bold italic");
     expect(stripMarkdown("___bold italic___")).toBe("bold italic");

--- a/src/lib/utils/strip-markdown.ts
+++ b/src/lib/utils/strip-markdown.ts
@@ -1,35 +1,24 @@
+/**
+ * Strips common Markdown syntax from a string, returning plain text suitable
+ * for use in previews and list item titles.
+ */
 export const stripMarkdown = (text: string): string => {
-  return (
-    text
-      // headings: ## Heading → Heading
-      .replaceAll(/^#{1,6}\s+/gm, "")
-      // blockquotes: > text → text
-      .replaceAll(/^>\s+/gm, "")
-      // unordered list markers: - item / * item
-      .replaceAll(/^[-*]\s+/gm, "")
-      // ordered list markers: 1. item
-      .replaceAll(/^\d+\.\s+/gm, "")
-      // images: ![alt](url) → alt
-      .replaceAll(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
-      // links: [text](url) → text
-      .replaceAll(/\[([^\]]*)\]\([^)]*\)/g, "$1")
-      // bold+italic: ***text*** / ___text___
-      .replaceAll(/\*{3}([^*]+)\*{3}/g, "$1")
-      .replaceAll(/_{3}([^_]+)_{3}/g, "$1")
-      // bold: **text** / __text__
-      .replaceAll(/\*{2}([^*]+)\*{2}/g, "$1")
-      .replaceAll(/_{2}([^_]+)_{2}/g, "$1")
-      // italic: *text* / _text_
-      .replaceAll(/\*([^*]+)\*/g, "$1")
-      .replaceAll(/_([^_]+)_/g, "$1")
-      // strikethrough: ~~text~~
-      .replaceAll(/~~([^~]+)~~/g, "$1")
-      // inline code: `code`
-      .replaceAll(/`([^`]+)`/g, "$1")
-      // horizontal rules
-      .replaceAll(/^[-*_]{3,}\s*$/gm, "")
-      // collapse extra whitespace
-      .replaceAll(/\s+/g, " ")
-      .trim()
-  );
+  return text
+    .replaceAll(/^#{1,6}\s+/gm, "")
+    .replaceAll(/^>\s+/gm, "")
+    .replaceAll(/^[-*]\s+/gm, "")
+    .replaceAll(/^\d+\.\s+/gm, "")
+    .replaceAll(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replaceAll(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replaceAll(/\*{3}([^*]+)\*{3}/g, "$1")
+    .replaceAll(/_{3}([^_]+)_{3}/g, "$1")
+    .replaceAll(/\*{2}([^*]+)\*{2}/g, "$1")
+    .replaceAll(/_{2}([^_]+)_{2}/g, "$1")
+    .replaceAll(/\*([^*]+)\*/g, "$1")
+    .replaceAll(/\b_([^_]+)_\b/g, "$1")
+    .replaceAll(/~~([^~]+)~~/g, "$1")
+    .replaceAll(/`([^`]+)`/g, "$1")
+    .replaceAll(/^[-*_]{3,}\s*$/gm, "")
+    .replaceAll(/\s+/g, " ")
+    .trim();
 };

--- a/src/lib/utils/strip-markdown.ts
+++ b/src/lib/utils/strip-markdown.ts
@@ -1,0 +1,35 @@
+export const stripMarkdown = (text: string): string => {
+  return (
+    text
+      // headings: ## Heading → Heading
+      .replaceAll(/^#{1,6}\s+/gm, "")
+      // blockquotes: > text → text
+      .replaceAll(/^>\s+/gm, "")
+      // unordered list markers: - item / * item
+      .replaceAll(/^[-*]\s+/gm, "")
+      // ordered list markers: 1. item
+      .replaceAll(/^\d+\.\s+/gm, "")
+      // images: ![alt](url) → alt
+      .replaceAll(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // links: [text](url) → text
+      .replaceAll(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+      // bold+italic: ***text*** / ___text___
+      .replaceAll(/\*{3}([^*]+)\*{3}/g, "$1")
+      .replaceAll(/_{3}([^_]+)_{3}/g, "$1")
+      // bold: **text** / __text__
+      .replaceAll(/\*{2}([^*]+)\*{2}/g, "$1")
+      .replaceAll(/_{2}([^_]+)_{2}/g, "$1")
+      // italic: *text* / _text_
+      .replaceAll(/\*([^*]+)\*/g, "$1")
+      .replaceAll(/_([^_]+)_/g, "$1")
+      // strikethrough: ~~text~~
+      .replaceAll(/~~([^~]+)~~/g, "$1")
+      // inline code: `code`
+      .replaceAll(/`([^`]+)`/g, "$1")
+      // horizontal rules
+      .replaceAll(/^[-*_]{3,}\s*$/gm, "")
+      // collapse extra whitespace
+      .replaceAll(/\s+/g, " ")
+      .trim()
+  );
+};

--- a/src/lib/utils/truncate.ts
+++ b/src/lib/utils/truncate.ts
@@ -1,5 +1,8 @@
-export const truncate = (content: string, maxLength: number) => {
+export const truncate = (content: string, maxLength: number): string => {
   if (content.length <= maxLength) return content;
 
-  return `${content.slice(0, Math.max(0, maxLength))}...`;
+  const sliced = content.slice(0, maxLength);
+  const lastSpace = sliced.lastIndexOf(" ");
+
+  return `${lastSpace > 0 ? sliced.slice(0, lastSpace) : sliced}...`;
 };


### PR DESCRIPTION
## Summary

- Replaces raw 200-char content truncation in note list items and recent notes with `extractNoteTitle()` — shows only the first non-empty line, markdown-stripped and word-boundary truncated to 80 chars
- Adds `stripMarkdown()` utility that removes heading markers, bold/italic, inline code, links, list markers, etc. via lightweight regex passes
- Updates `truncate()` to cut at the nearest word boundary instead of hard-slicing mid-word
- Removes the body preview from list items entirely — title only, consistent with the app's simplicity philosophy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List views now display note titles derived from the first non-empty line and strip Markdown for cleaner titles.
* **Bug Fixes**
  * Text truncation now prefers word boundaries, avoiding mid-word cuts when shortening text.
* **Tests**
  * Added comprehensive tests covering title extraction, Markdown stripping, and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->