### PR TITLE
fix(tauri): 🐛 gate the reopen arm to macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,31 @@ jobs:
         run: pnpm build:web
 
   rust:
-    # macOS runners need no system deps to compile the tauri crate.
-    runs-on: macos-latest
+    # Both targets, because a platform-gated arm compiles on one and not the
+    # other. release.yml's check job runs on Linux, so a macOS-only gate here
+    # lets that class of error reach a tag: `RunEvent::Reopen` did.
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
     needs: code_check
 
     steps:
       - name: 🏗 Setup Repository
         uses: actions/checkout@v4
+
+      # macOS needs none of these; the tauri crate links webkit2gtk through
+      # pkg-config, which is why release.yml installs the same set.
+      - name: 🐧 Setup Linux Deps
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
 
       - name: 🦀 Setup Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/SPEC.md
+++ b/SPEC.md
@@ -52,7 +52,9 @@ walkthrough is their only coverage. Run it under `pnpm dev`.
   with `ci.yml`, so it is its own change)
 - Sharing one gate between `ci.yml`'s `code_check` and `release.yml`'s `check`
   (they duplicate each other and have already diverged; `AGENTS.md` says
-  surface the second occurrence and wait for the third before extracting)
+  surface the second occurrence and wait for the third before extracting). The
+  Linux dep install is now the third copy, across `ci.yml`'s `rust` job and
+  `release.yml`'s `check` and `build`, so that half has reached the rule
 - A verified minimum macOS version for the cask (`tauri.conf.json` sets none, so
   the bundle carries Tauri's 10.13 default; nothing has tested the real floor,
   so the cask declares no `depends_on macos:`)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -302,6 +302,9 @@ pub fn run() {
         .expect("error while building notras");
 
     app.run(|app, event| match event {
+        // macOS only: the variant does not exist on the other targets, and an
+        // ungated arm is a Linux compile error the macOS gate cannot see.
+        #[cfg(target_os = "macos")]
         RunEvent::Reopen { .. } => show_main(app),
         // Every quit (⌘Q, tray, `quit_app`) funnels through here. The first one
         // is held back so the webview can flush unsaved buffers; the frontend


### PR DESCRIPTION
## What

Adds `#[cfg(target_os = "macos")]` to the `RunEvent::Reopen` arm in `src-tauri/src/lib.rs`, and gives `ci.yml`'s `rust` job a `macos-latest` plus `ubuntu-latest` matrix so a pull request compiles the crate for both.

## Why

`RunEvent::Reopen` is `#[cfg(target_os = "macos")]` in tauri. The arm carried no cfg, so the crate does not compile for linux, and `release.yml`'s `check` job runs on ubuntu. It failed with `E0599: no variant named `Reopen` found for enum `RunEvent`` before `build` ran, which left the `v0.1.1` GitHub release a draft with no assets.

The line dates to the original tauri port and reached a tag because the two gates run on different systems: `ci.yml`'s `rust` job on macos-latest, `release.yml`'s `check` on ubuntu-latest. No pull request had ever compiled this crate for linux, so the matrix is the part that stops it recurring rather than the cfg attribute. If it is wrong, the linux leg of this pull request fails, which is the same signal that was missing before.

`Reopen` is the only ungated macos item in the crate: `objc2` and `objc2-app-kit` are already behind `[target.'cfg(target_os = "macos")'.dependencies]`, and the other five cfg sites are correct. `show_main` stays reachable on linux through the tray handler, so gating the arm raises no dead-code warning. Verified locally by inverting the cfg to `linux` and compiling on macos: the match stays exhaustive and clippy is clean with the arm excluded.

The apt block is now its third copy across `ci.yml`'s `rust` job and `release.yml`'s `check` and `build`. `SPEC.md` records that against the existing deferred entry for sharing one gate rather than extracting it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI coverage for both macOS and Ubuntu builds.
  * Ubuntu builds now automatically install required system dependencies.

* **Bug Fixes**
  * Improved cross-platform compatibility by preventing macOS-specific event handling from affecting non-macOS builds.

* **Documentation**
  * Updated workflow documentation to reflect the expanded Linux setup and shared configuration needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->