### PR TITLE
feat: ✨ compact title bar

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -466,8 +466,8 @@ re-examines it for one glyph, which the width argument does not reach.
 
 The app was spending two bands on one band's work: an empty drag strip above a
 header. Folding one into the other returns 32px to the note and puts the title
-where macOS puts a document title. The bar is 44px so the traffic lights `D29`
-centres in it land on the title's line.
+where macOS puts a document title. The traffic lights `D29` centres in the bar
+land on the title's line.
 
 Each route renders its own titlebar rather than the root rendering one, because
 a shared root strip cannot hold per-route content and TanStack Router has no
@@ -514,16 +514,30 @@ notras.
 HTML in a webview, so this cannot resize anything unintended. That stops being
 true if native menus or panels are ever added.
 
-**Constraint:** `trafficLightPosition` is `{ x: 16, y: 24 }`, paired with the
-44px band in `src/components/titlebar.tsx`. Both come from
-[erictli/scratch](https://github.com/erictli/scratch), which ships them against
-the same overlay titlebar, rather than from derivation here.
+**Constraint:** `trafficLightPosition` is `{ x: 16, y: 20 }`, paired with the
+36px band in `src/components/titlebar.tsx`. The band was 44px, from
+erictli/scratch rather than from a reading of what a title bar should be, and
+`D51`'s survey put that above the median of comparable desktop apps. It is
+carried twice, in `tauri.conf.json` for the `main` window and as
+`TRAFFIC_LIGHTS` in `lib.rs` for `capture`, so a band change edits both or the
+two windows disagree.
 
-`y` is not a margin above the buttons. tao's `inset_traffic_lights` resizes the
-titlebar container to `buttonHeight + y`, anchors it to the window top, and
-leaves each button's offset inside it untouched, so in AppKit's bottom-up
-coordinates `y` lands as the button's **centre offset from the window top**.
-Misreading that cost four rounds: 12 in a 36px bar centred the buttons at 12pt
+`y` is neither a margin above the buttons nor their centre. tao's
+`inset_traffic_lights` resizes the titlebar container to `buttonHeight + y`,
+anchors it to the window top, and assigns only `origin.x`, so a button keeps the
+`origin.y` AppKit gave it and rides down as the container grows. Writing that
+resting offset as `b`, the button lands `y - b` below the window top and
+
+```txt
+y = (height - buttonHeight) / 2 + b
+```
+
+`b` is 9 here, which erictli/scratch and Dimillian/CodexMonitor corroborate at
+44 with `y` 24 and athasdev/athas at 36 with `y` 20. readest derives the same
+formula at runtime but measures `b` at 5 to 7, so it is not portable across
+macOS versions or control metrics and a band change is verified by looking.
+
+Misreading this cost four rounds: 12 in a 36px bar put the buttons at 3pt
 against content at 18pt and crowded them into the rounded corner, and removing
 the override entirely traded the misalignment for a bar too tight to breathe.
 
@@ -547,8 +561,8 @@ substring-matched a vocabulary it recomputed on every keystroke, disagreeing
 with the index it stood in for.
 
 Tags moved down because the titlebar could not hold them: `D28` put title, tags,
-and pin in one 44px band, where the chip row was pinned to `w-16` to keep the
-title readable. The status strip is where the note's other metadata already
+and pin in one band, where the chip row was pinned to `w-16` to keep the title
+readable. The status strip is where the note's other metadata already
 sits.
 
 **Rejected: keeping tags in the titlebar with the combobox inline.** Smallest
@@ -855,8 +869,8 @@ count and three toggles, it reads as an indicator of something.
 for an app that autosaves. `D38` re-rejects it on harder grounds once a `failed`
 state exists.
 
-**Constraint:** the glyphs differ by a badge roughly 4px wide at `size-3.5`, so
-tone carries the rest and `DESIGN.md` assigns it. Changing a tone makes the
+**Constraint:** the glyphs differ by a badge roughly 4px wide at `CHROME_GLYPH`,
+so tone carries the rest and `DESIGN.md` assigns it. Changing a tone makes the
 states harder to tell apart rather than only quieter.
 
 **Constraint:** the indicator is a status and not a control, so its tooltip
@@ -1304,3 +1318,34 @@ collides with the caller's own group and cancels it.
 fails. `ci.yml` resolves `./.github/actions/setup-rust` and `release.yml`
 resolves `.github/homebrew/` out of the checked-out tag, and no tag through
 v0.1.2 carries either.
+
+### D51 Chrome glyphs take a role-based rung, stated outside the generated variant
+
+A standalone glyph in a chrome control is `CHROME_GLYPH` in
+`src/lib/ui/chrome.ts`, covering the save indicator, the pin and the three view
+toggles. An icon beside a word takes the 12px its button variant already gives
+it, uncorrected, which is `add tag` and the palette's pin marker. The rung
+follows the role the icon plays, not the band it sits in.
+
+The app had three numbers for one thing, and the pin and the save glyph sat
+adjacent in the titlebar in identical 24px boxes at different sizes, which is
+how it surfaced. A pass at 12px, the `icon-xs` rung's own value, came first and
+was too small for a control.
+
+**Rejected: editing the `icon-xs` variant.** The obvious fix, needing no
+call-site class at all. Rejected because `icon-xs` is defined twice, in
+`toggle.tsx` as this repo's `D19` deviation and in `button.tsx` as upstream's,
+and `scripts/update-shadcn.sh` patches nothing back. Editing one makes a rung
+name mean two sizes; editing both adds a deviation regeneration silently
+reverts. `D37` met the same fork for the pressed state and put the override in a
+named constant, which is what `PRESSED` is.
+
+**Constraint:** `saved` came off `--faint`, which is 2.65:1 in dark and below
+the 3:1 WCAG sets for non-text, and onto the `opacity-60` the pin beside it
+already uses when idle. So the glyph is `--foreground` while a write is
+outstanding and dim once it lands, which is `DESIGN.md`'s muted-when-idle rule
+rather than a tone of its own.
+
+**Constraint:** the glyph carries `[stroke-width:2.25]`. Lucide's stroke is 2
+against a 24-unit `viewBox`, so it scales with the glyph and 14px would render
+1.167px, lighter than the 1.333px an unstyled lucide icon draws at 16px here.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -215,12 +215,12 @@ a real non-motion end state, so removing the transition costs nothing.
 - **The save state is a glyph, and it sits in the titlebar** (`D35`, `D38`).
   `SaveIndicator` renders between the title and the pin, a floppy carrying a pen
   for `dirty`, no badge for `saving`, a check for `saved`, and a slash for
-  `failed`, at `size-3.5` in the same 24px box the pin and the view toggles use.
-  `saved` drops to `--faint` and `failed` takes `--destructive`; `dirty` and
-  `saving` set no tone and inherit the bar's, so tone separates the states the
-  badge alone would not at that size. The word reaches a hover tooltip and `sr-only` text,
-  never the bar. The external-file route renders the same component in its own
-  titlebar, which is why it carries `no-drag`.
+  `failed`, at `CHROME_GLYPH` in the same 24px box the pin and the view toggles
+  use. `saved` takes the pin's idle `opacity-60` and `failed` takes
+  `--destructive`; `dirty` and `saving` inherit the bar's, so the glyph is lit
+  while a write is outstanding and dim once it lands. The word reaches a hover
+  tooltip and `sr-only` text, never the bar. The external-file route renders the
+  same component in its own titlebar, which is why it carries `no-drag`.
 - **Anything in chrome that turns on and off is a `Toggle`** (`D37`), at
   `size="icon-xs"`, showing its on-state as `--foreground`. That covers the
   three view toggles, which are one `ToggleGroup` and so one tab stop with arrow
@@ -228,6 +228,11 @@ a real non-motion end state, so removing the transition costs nothing.
   it: `--muted-foreground` in the status strip, and `--foreground` at
   `opacity-60` for the pin, since the titlebar carries no muted tone. Hover is a surface and pressed is a tone, which is what keeps the two
   states apart.
+- **A glyph's size follows its role, not its band** (`D51`). A standalone glyph
+  in a chrome control takes `CHROME_GLYPH` from `src/lib/ui/chrome.ts`. An icon
+  beside a word takes 12px, which its button variant usually supplies and the
+  palette's pin marker has to state. Those are the only two roles, so a `size-*`
+  class on an icon anywhere else means the wrong component is wrapping it.
 - **Tags are picked from the status strip** (`D30`). A chip reads `#groceries`
   and filters to that tag; the `TagPlus` button beside it reads `add tag` and
   opens the combobox, whose vocabulary is the index's own counted tag list. The
@@ -241,11 +246,12 @@ a real non-motion end state, so removing the transition costs nothing.
   is a platform fact and lives in one place. Windows and Linux put the controls
   on the right, and would need it mirrored.
 - **The titlebar height and the traffic light offset are one decision.** The bar
-  is 44px and `trafficLightPosition` centres the buttons in it, so plain centring
+  is 36px and `trafficLightPosition` centres the buttons in it, so plain centring
   puts the title on their line and the space above and below them is equal by
-  construction. Both values come from scratch, which ships them against the same
-  overlay titlebar. Changing the height means rechecking the offset, and `D29`
-  records what happens when they drift apart.
+  construction. The offset is carried twice, in `tauri.conf.json` for the `main`
+  window and in `lib.rs` for `capture`, so both move together. Changing the
+  height means rechecking them, and `D29` records what happens when they drift
+  apart.
 - **Two bands frame the note.** The titlebar above and the status strip below,
   each with a hairline border. A band that reads as chrome needs an edge, and
   without one the title floats as stray text over the document.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,12 +26,10 @@ use crate::state::{AppState, Core};
 const BG_DARK: Color = Color(0x19, 0x1b, 0x1d, 255);
 const BG_LIGHT: Color = Color(0xf7, 0xf8, 0xfa, 255);
 
-/// Centres the buttons in the 44px band `Titlebar` draws. The pair comes from
-/// erictli/scratch, which ships these values against the same overlay titlebar;
-/// `y` is the button's centre offset from the window top, not a margin above it.
-/// Changing the band height means rechecking this.
+/// Centres the buttons in the 36px band `Titlebar` draws; `D29` derives `y` and
+/// `tauri.conf.json` carries the same pair for the `main` window.
 #[cfg(target_os = "macos")]
-const TRAFFIC_LIGHTS: tauri::LogicalPosition<f64> = tauri::LogicalPosition::new(16.0, 24.0);
+const TRAFFIC_LIGHTS: tauri::LogicalPosition<f64> = tauri::LogicalPosition::new(16.0, 20.0);
 
 fn background_for(theme: Theme) -> Color {
     match theme {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
         "hiddenTitle": true,
         "dragDropEnabled": true,
         "backgroundColor": "#191b1d",
-        "trafficLightPosition": { "x": 16, "y": 24 }
+        "trafficLightPosition": { "x": 16, "y": 20 }
       }
     ],
     "security": {

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -100,6 +100,7 @@ function NoteItem({ note, onSelect }: NoteItemProps) {
       <div className="flex min-w-0 flex-col">
         <span className="flex items-center gap-1.5 truncate">
           {note.title}
+          {/* In a text run, not the row's icon slot, so it stays 12px (`D51`). */}
           {note.pinned ? <PinIcon className="size-3 opacity-60" /> : null}
           {note.folder === "" ? null : (
             <span className="text-muted-foreground text-xs">

--- a/src/components/notes/note-header.tsx
+++ b/src/components/notes/note-header.tsx
@@ -12,6 +12,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { setNotePinned } from "@/data/pin-note";
+import { CHROME_GLYPH } from "@/lib/ui/chrome";
+import { cn } from "@/lib/ui/utils";
 
 interface NoteHeaderProps {
   path: string;
@@ -64,9 +66,9 @@ export function NoteHeader({ path, pinned, status, title }: NoteHeaderProps) {
           }
         >
           {optimisticPinned ? (
-            <PinIcon className="size-4" />
+            <PinIcon className={CHROME_GLYPH} />
           ) : (
-            <PinOffIcon className="size-4 opacity-60" />
+            <PinOffIcon className={cn(CHROME_GLYPH, "opacity-60")} />
           )}
         </TooltipTrigger>
         <TooltipContent>{optimisticPinned ? "unpin" : "pin"}</TooltipContent>

--- a/src/components/notes/save-indicator.tsx
+++ b/src/components/notes/save-indicator.tsx
@@ -12,20 +12,21 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { CHROME_GLYPH } from "@/lib/ui/chrome";
 import { cn } from "@/lib/ui/utils";
 
 const STATUS: Record<
   SaveStatus,
-  { icon: typeof SaveIcon; label: string; tone: string }
+  { icon: typeof SaveIcon; label: string; tone?: string }
 > = {
-  dirty: { icon: SavePenIcon, label: "unsaved", tone: "" },
+  dirty: { icon: SavePenIcon, label: "unsaved" },
   failed: {
     icon: SaveOffIcon,
     label: "could not save",
     tone: "text-destructive",
   },
-  saved: { icon: SaveCheckIcon, label: "saved", tone: "text-faint" },
-  saving: { icon: SaveIcon, label: "saving", tone: "" },
+  saved: { icon: SaveCheckIcon, label: "saved", tone: "opacity-60" },
+  saving: { icon: SaveIcon, label: "saving" },
 };
 
 interface SaveIndicatorProps {
@@ -55,7 +56,7 @@ export function SaveIndicator({ status }: SaveIndicatorProps) {
           />
         }
       >
-        <Icon className="size-3.5" />
+        <Icon className={CHROME_GLYPH} />
         <span className="sr-only">{label}</span>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>

--- a/src/components/notes/status-bar.tsx
+++ b/src/components/notes/status-bar.tsx
@@ -9,6 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { CHROME_GLYPH } from "@/lib/ui/chrome";
 import { readingTime } from "@/lib/utils/word-count";
 
 /** Tone for pressed and surface for hover, which the shipped variant collapses into one. */
@@ -118,7 +119,7 @@ export function StatusBar({
                 />
               }
             >
-              <Icon className="size-3.5" />
+              <Icon className={CHROME_GLYPH} />
             </TooltipTrigger>
             <TooltipContent>
               {label} {hint === "" ? null : <Kbd>{hint}</Kbd>}

--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -7,17 +7,16 @@ interface TitlebarProps {
 /**
  * The window drag region, and the only chrome above the note.
  *
- * The 44px height pairs with `TRAFFIC_LIGHTS` in `src-tauri/src/lib.rs`, which
- * centres macOS's window buttons in it, so ordinary centring puts everything on
- * one line (`D29`). Both values come from erictli/scratch; changing this height
- * means rechecking that offset. The buttons float over the top left, so
- * `ps-titlebar` starts the content after them, and buttons and inputs opt out of
- * dragging through `styles.css`.
+ * The 36px height pairs with the traffic light offset `D29` carries, in both
+ * `tauri.conf.json` and `src-tauri/src/lib.rs`, which centres macOS's window
+ * buttons in it; changing this height means rechecking both. The buttons float
+ * over the top left, so `ps-titlebar` starts the content after them, and
+ * buttons and inputs opt out of dragging through `styles.css`.
  */
 export function Titlebar({ children }: TitlebarProps) {
   return (
     <div
-      className="titlebar-drag-region flex h-11 shrink-0 items-center border-b ps-titlebar pe-3"
+      className="titlebar-drag-region flex h-9 shrink-0 items-center border-b ps-titlebar pe-3"
       data-tauri-drag-region
     >
       {children}

--- a/src/lib/ui/chrome.ts
+++ b/src/lib/ui/chrome.ts
@@ -1,0 +1,9 @@
+/**
+ * How a standalone glyph in a chrome control is drawn (`D51`).
+ *
+ * The stroke is not lucide's default: its 2 is against a 24-unit `viewBox`, so
+ * it scales down with the glyph and 14px would render 1.167px. `strokeWidth`
+ * and `absoluteStrokeWidth` both compute from the `size` prop, which sizing by
+ * class leaves at 24, so the correction has to be CSS.
+ */
+export const CHROME_GLYPH = "size-3.5 [stroke-width:2.25]";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reduced the title bar height for a more compact layout.
  * Updated macOS window controls to remain correctly centered.
  * Standardized chrome icon sizing and stroke weight across the interface.
  * Refined pin, toggle, and save-state icon appearance.
  * Saved indicators now appear more subdued, while failed states use an error color.

* **Documentation**
  * Updated design and decision records to reflect the revised title bar and icon styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->