### PR TITLE
fix: 🐛 prevent elastic scrolling on window

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -200,6 +200,11 @@ animation, no entrance choreography beyond the platform's own, and no spring.
 - Shadcn primitives carry their own hover and press transitions, and the toast
   spinner spins. Beyond those, `src/styles.css` animates only focus mode,
   wikilinks, and the code-block toolbar and its buttons.
+- The window does not bounce. `html` sets `overscroll-behavior: none`, so a
+  flick past the end of a note stays in the note rather than chaining into the
+  document and dragging the titlebar, the tab strip and the status strip with
+  it. A scroller keeps the bounce of its own, which is what an NSScrollView
+  does.
 
 `prefers-reduced-motion: reduce` collapses all of it. Every animation above has
 a real non-motion end state, so removing the transition costs nothing.

--- a/SPEC.md
+++ b/SPEC.md
@@ -83,6 +83,11 @@ walkthrough is their only coverage. Run it under `pnpm dev`.
 - [ ] 25b. Type into a note, ⌘K → "rename note...", then ⌘Z → the undo reaches
       the text typed before the rename, and the caret and scroll are where they
       were left; ⌘K → "move to folder..." on the same tab does the same
+- [ ] 26. Scroll hard past the bottom and then the top of a note longer than the
+      window, and flick the tab strip sideways past the last tab → the note
+      settles at its bounds and the titlebar, the tab strip and the status strip
+      do not move. ⌘P and the capture window are separate scrollers and get the
+      same two passes
 
 ## Deferred
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -162,6 +162,16 @@
     -webkit-user-select: text;
     user-select: text;
   }
+  /* Elastic scrolling belongs to the note, not the window. WebKit bounces the
+     document even with nothing to scroll, and an inner scroller chains what is
+     left of a flick into it, so scrolling past the end of a note dragged the
+     titlebar, the tab strip and the status strip along with it. `none` on the
+     viewport ends both, and each scroller keeps the bounce of its own, which is
+     what an NSScrollView does. `overflow: hidden` would also stop it, by
+     clipping a real overflow rather than showing it. */
+  html {
+    overscroll-behavior: none;
+  }
   /* Motion carries a state change, so removing it costs nothing but the
      transition. Every animation here has a real non-motion end state. */
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scrolling behavior by preventing unwanted overscroll chaining at the window level.
  * Preserved independent bounce and scrolling behavior within individual scrollable areas.

* **Documentation**
  * Added guidance and verification checks for scrolling boundaries across notes, tabs, title bars, status areas, print views, and capture views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->