### PR TITLE
feat: ✨ add syntax highlighting for Markdown frontmatter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -153,11 +153,6 @@ walkthrough is their only coverage. Run it under `pnpm dev`.
   `resolveImageSrc`. Opening one needs `opener:allow-open-path`, which
   `opener:default` does not carry, plus a scope naming which paths the app may
   hand to the system. Deferred on that scope, not on the wiring
-- The focus guard `SourceEditor` never got. `Editor` places a restored caret
-  without taking focus (`editor.tsx:390`), while the source surface calls
-  `.focus()` unconditionally on create and on mount. Its key carries `reloadKey`
-  (`note-session.tsx:426`), which an external edit bumps for any tab, so a
-  background tab left in source mode steals the caret from the one being typed in
 - A focus-visible affordance for `.link-editor-input` and `.code-block-language`,
   which set `outline: none` and replace nothing
 - A message on `DatabaseError` (`src/core/errors.ts`), which carries only

--- a/SPEC.md
+++ b/SPEC.md
@@ -153,6 +153,11 @@ walkthrough is their only coverage. Run it under `pnpm dev`.
   `resolveImageSrc`. Opening one needs `opener:allow-open-path`, which
   `opener:default` does not carry, plus a scope naming which paths the app may
   hand to the system. Deferred on that scope, not on the wiring
+- The focus guard `SourceEditor` never got. `Editor` places a restored caret
+  without taking focus (`editor.tsx:390`), while the source surface calls
+  `.focus()` unconditionally on create and on mount. Its key carries `reloadKey`
+  (`note-session.tsx:426`), which an external edit bumps for any tab, so a
+  background tab left in source mode steals the caret from the one being typed in
 - A focus-visible affordance for `.link-editor-input` and `.code-block-language`,
   which set `outline: none` and replace nothing
 - A message on `DatabaseError` (`src/core/errors.ts`), which carries only

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/utils/attachments";
 
 import { CodeBlockView } from "./code-block-view";
+import { markdownWithFrontmatter } from "./markdown-frontmatter";
 import { SlashMenu } from "./slash-menu";
 import { Wikilink } from "./wikilink";
 
@@ -31,7 +32,10 @@ export interface EditorExtensionOptions {
   resolveImageSrc?: (src: string) => string;
 }
 
-export const lowlight = createLowlight(common);
+export const lowlight = createLowlight({
+  ...common,
+  markdown: markdownWithFrontmatter,
+});
 
 /**
  * TipTap's `excludes: "_"` refuses a text node holding `code` beside any other

--- a/src/components/editor/markdown-frontmatter.spec.ts
+++ b/src/components/editor/markdown-frontmatter.spec.ts
@@ -68,6 +68,13 @@ describe("markdown with frontmatter", () => {
     });
   });
 
+  it("should close a frontmatter block on a delimiter with trailing spaces", () => {
+    expect(tokens("---\npinned: true\n---  \n# a title")).toContainEqual({
+      text: "# a title",
+      token: "hljs-section",
+    });
+  });
+
   it("should still highlight a heading after the frontmatter block", () => {
     expect(tokens("---\npinned: true\n---\n# a title")).toContainEqual({
       text: "# a title",

--- a/src/components/editor/markdown-frontmatter.spec.ts
+++ b/src/components/editor/markdown-frontmatter.spec.ts
@@ -1,0 +1,70 @@
+import { common, createLowlight } from "lowlight";
+import { describe, expect, it } from "vitest";
+
+import { markdownWithFrontmatter } from "./markdown-frontmatter";
+
+const lowlight = createLowlight({
+  ...common,
+  markdown: markdownWithFrontmatter,
+});
+
+type Content = ReturnType<typeof lowlight.highlight>["children"][number];
+
+/** Every run of text a reader sees, paired with the class painting it. */
+const tokens = (source: string) => {
+  const flat: { text: string; token: string }[] = [];
+
+  const walk = (node: Content, inherited: string) => {
+    if (node.type === "text") {
+      flat.push({ text: node.value, token: inherited });
+
+      return;
+    }
+
+    if (node.type !== "element") {
+      return;
+    }
+
+    const own = node.properties.className;
+    const token = Array.isArray(own) ? own.join(" ") : inherited;
+
+    for (const child of node.children) {
+      walk(child, token);
+    }
+  };
+
+  for (const child of lowlight.highlight("markdown", source).children) {
+    walk(child, "");
+  }
+
+  return flat;
+};
+
+describe("markdown with frontmatter", () => {
+  it("should highlight a frontmatter key as a yaml attribute", () => {
+    expect(tokens("---\npinned: true\n---\n# a title")).toContainEqual({
+      text: "pinned:",
+      token: "hljs-attr",
+    });
+  });
+
+  it("should not read a closing --- as a setext heading", () => {
+    expect(tokens("---\ntags: [notras]\n---\n# a title")).not.toContainEqual({
+      text: "tags: [notras]\n---",
+      token: "hljs-section",
+    });
+  });
+
+  it("should leave a --- pair below the frontmatter unhighlighted", () => {
+    expect(
+      tokens("---\npinned: true\n---\nbefore\n\n---\n\nafter")
+    ).toContainEqual({ text: "\nbefore\n\n---\n\nafter", token: "" });
+  });
+
+  it("should still highlight a heading after the frontmatter block", () => {
+    expect(tokens("---\npinned: true\n---\n# a title")).toContainEqual({
+      text: "# a title",
+      token: "hljs-section",
+    });
+  });
+});

--- a/src/components/editor/markdown-frontmatter.spec.ts
+++ b/src/components/editor/markdown-frontmatter.spec.ts
@@ -61,6 +61,13 @@ describe("markdown with frontmatter", () => {
     ).toContainEqual({ text: "\nbefore\n\n---\n\nafter", token: "" });
   });
 
+  it("should close a frontmatter block on a ... delimiter", () => {
+    expect(tokens("---\npinned: true\n...\n# a title")).toContainEqual({
+      text: "# a title",
+      token: "hljs-section",
+    });
+  });
+
   it("should still highlight a heading after the frontmatter block", () => {
     expect(tokens("---\npinned: true\n---\n# a title")).toContainEqual({
       text: "# a title",

--- a/src/components/editor/markdown-frontmatter.ts
+++ b/src/components/editor/markdown-frontmatter.ts
@@ -10,8 +10,12 @@ if (markdown === undefined) {
 
 const OPEN = /^---$/;
 
-/** Both closes `parseNote` accepts (`frontmatter.ts`), so the two agree. */
-const CLOSE = /^(?:---|\.{3})$/;
+/**
+ * Both closes `parseNote` accepts, trailing spaces and all, so the two agree.
+ * `[^\S\n]` and not `\s`: highlight.js compiles these multiline, and matching
+ * the newline would run the block on past its delimiter.
+ */
+const CLOSE = /^(?:---|\.{3})[^\S\n]*$/;
 
 /**
  * highlight.js ships no frontmatter rule, so its setext-heading mode reads a

--- a/src/components/editor/markdown-frontmatter.ts
+++ b/src/components/editor/markdown-frontmatter.ts
@@ -1,0 +1,48 @@
+import type { LanguageFn } from "lowlight";
+
+import { common } from "lowlight";
+
+const { markdown } = common;
+
+if (markdown === undefined) {
+  throw new Error("lowlight's common set no longer carries markdown");
+}
+
+/**
+ * Both fences of the block. highlight.js compiles a mode's `begin` and `end`
+ * from `source`, so one literal serves both without carrying a `lastIndex`
+ * between them.
+ */
+const DELIMITER = /^---$/;
+
+/**
+ * highlight.js ships no frontmatter rule, so its setext-heading mode reads a
+ * closing `---` as an underline and paints the key line above it as a heading.
+ * A YAML block placed ahead of that mode beats it to the match and gives the
+ * block real keys, values and delimiters.
+ */
+export const markdownWithFrontmatter: LanguageFn = (hljs) => {
+  const base = markdown(hljs);
+
+  return {
+    ...base,
+    contains: [
+      {
+        begin: DELIMITER,
+        end: DELIMITER,
+        // Frontmatter is the block at offset 0 and nothing else: further down
+        // a `---` pair is two thematic breaks with markdown between them.
+        "on:begin": (match, response) => {
+          if (match.index !== 0) {
+            response.ignoreMatch();
+          }
+        },
+        // Autodetect scores an unlabelled fence (`extensions.ts`), and this
+        // mode exists to fix rendering, not to make markdown a likelier guess.
+        relevance: 0,
+        subLanguage: "yaml",
+      },
+      ...base.contains,
+    ],
+  };
+};

--- a/src/components/editor/markdown-frontmatter.ts
+++ b/src/components/editor/markdown-frontmatter.ts
@@ -8,12 +8,10 @@ if (markdown === undefined) {
   throw new Error("lowlight's common set no longer carries markdown");
 }
 
-/**
- * Both fences of the block. highlight.js compiles a mode's `begin` and `end`
- * from `source`, so one literal serves both without carrying a `lastIndex`
- * between them.
- */
-const DELIMITER = /^---$/;
+const OPEN = /^---$/;
+
+/** Both closes `parseNote` accepts (`frontmatter.ts`), so the two agree. */
+const CLOSE = /^(?:---|\.{3})$/;
 
 /**
  * highlight.js ships no frontmatter rule, so its setext-heading mode reads a
@@ -28,8 +26,8 @@ export const markdownWithFrontmatter: LanguageFn = (hljs) => {
     ...base,
     contains: [
       {
-        begin: DELIMITER,
-        end: DELIMITER,
+        begin: OPEN,
+        end: CLOSE,
         // Frontmatter is the block at offset 0 and nothing else: further down
         // a `---` pair is two thematic breaks with markdown between them.
         "on:begin": (match, response) => {

--- a/src/components/editor/source-editor.spec.tsx
+++ b/src/components/editor/source-editor.spec.tsx
@@ -1,0 +1,64 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { SourceEditor } from "./source-editor";
+
+// `act` refuses to run without this, and no setup file exists to set it.
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+let teardown: (() => void) | null = null;
+
+afterEach(() => {
+  teardown?.();
+  teardown = null;
+});
+
+/**
+ * Mount the editor beside an already-focused button. The caret lands in a mount
+ * effect, so the render has to be flushed before focus is read.
+ */
+const mountBeside = async (focusOnMount: boolean) => {
+  const button = document.createElement("button");
+  const host = document.createElement("div");
+
+  document.body.append(button, host);
+  button.focus();
+
+  const root = createRoot(host);
+
+  await act(async () => {
+    root.render(
+      createElement(SourceEditor, {
+        focusOnMount,
+        initialValue: "---\npinned: true\n---\n# a title",
+        onChange: () => undefined,
+      })
+    );
+    await Promise.resolve();
+  });
+
+  teardown = () => {
+    act(() => {
+      root.unmount();
+    });
+    button.remove();
+    host.remove();
+  };
+
+  return { button, host };
+};
+
+describe("source editor focus", () => {
+  it("should leave focus alone when it is not the active surface", async () => {
+    const { button } = await mountBeside(false);
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it("should take focus when mounted as the active surface", async () => {
+    const { host } = await mountBeside(true);
+
+    expect(document.activeElement).toBe(host.querySelector(".ProseMirror"));
+  });
+});

--- a/src/components/editor/source-editor.tsx
+++ b/src/components/editor/source-editor.tsx
@@ -19,6 +19,7 @@ export interface SourceEditorHandle {
 }
 
 interface SourceEditorProps {
+  focusOnMount?: boolean;
   /** Character offset to place the caret at on mount. */
   initialCursor?: number;
   /** The whole raw file, frontmatter included -- frozen at mount. */
@@ -80,16 +81,18 @@ function caretPosition(editor: Editor, offset: number) {
 /**
  * Raw markdown source mode (⌘P): the whole file in a single code block,
  * syntax-highlighted with lowlight's markdown grammar and backed by real
- * undo. The caret lands on the block you were editing (see
- * source-anchors.ts) and the same autosave drives writes.
+ * undo. The caret lands on the block you were editing (see sentinel.ts) and
+ * the same autosave drives writes.
  */
 export function SourceEditor({
+  focusOnMount,
   initialCursor = 0,
   initialValue,
   onChange,
   onReady,
 }: SourceEditorProps) {
   const [config] = useState(() => ({
+    focusOnMount,
     initialCursor,
     initialValue,
     onChange,
@@ -132,13 +135,6 @@ export function SourceEditor({
     ],
     immediatelyRender: false,
     onCreate: ({ editor: instance }) => {
-      instance
-        .chain()
-        .focus()
-        .setTextSelection(caretPosition(instance, config.initialCursor))
-        .scrollIntoView()
-        .run();
-
       config.onReady?.({
         focus: () => {
           if (!instance.isDestroyed) {
@@ -161,16 +157,22 @@ export function SourceEditor({
     },
   });
 
-  // Focus and caret placement only work once EditorContent has attached
-  // the view to the DOM, which happens before this parent effect runs.
+  // Caret placement only works once EditorContent has attached the view to the
+  // DOM, which happens before this parent effect runs.
   useEffect(() => {
     if (editor === null || editor.isDestroyed) {
       return;
     }
 
-    editor
-      .chain()
-      .focus()
+    const chain = editor.chain();
+
+    // A tab mounted in the background places its caret without taking focus:
+    // every open tab keeps a live editor and only one is showing.
+    if (config.focusOnMount === true) {
+      chain.focus();
+    }
+
+    chain
       .setTextSelection(caretPosition(editor, config.initialCursor))
       .scrollIntoView()
       .run();

--- a/src/components/editor/source-editor.tsx
+++ b/src/components/editor/source-editor.tsx
@@ -9,6 +9,8 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { common, createLowlight } from "lowlight";
 import { useEffect, useState } from "react";
 
+import { markdownWithFrontmatter } from "./markdown-frontmatter";
+
 export interface SourceEditorHandle {
   focus: () => void;
   /** Caret position as a character offset into the raw text. */
@@ -25,7 +27,10 @@ interface SourceEditorProps {
   onReady?: (handle: SourceEditorHandle) => void;
 }
 
-const lowlight = createLowlight(common);
+const lowlight = createLowlight({
+  ...common,
+  markdown: markdownWithFrontmatter,
+});
 
 const SourceDocument = Document.extend({
   content: "codeBlock",

--- a/src/components/workspace/note-session.tsx
+++ b/src/components/workspace/note-session.tsx
@@ -85,13 +85,13 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
 
   // The rich editor owns the BODY; frontmatter rides along from the latest
   // read so pin/tag toggles are never clobbered by a body save.
-  const [frontmatterLines, setFrontmatterLines] = useState(
-    () => parseNote(file.content).rawLines
+  const [frontmatterBlock, setFrontmatterLines] = useState(
+    () => parseNote(file.content).raw
   );
-  const frontmatterRef = useRef(frontmatterLines);
+  const frontmatterRef = useRef(frontmatterBlock);
 
   useEffect(() => {
-    frontmatterRef.current = frontmatterLines;
+    frontmatterRef.current = frontmatterBlock;
   });
 
   // Frontmatter follows the file (adjust-during-render pattern): a pin or tag
@@ -102,9 +102,10 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   if (syncedContent !== file.content) {
     setSyncedContent(file.content);
 
-    const fresh = parseNote(file.content).rawLines;
+    const fresh = parseNote(file.content).raw;
 
-    if (fresh.join("\n") !== frontmatterLines.join("\n")) {
+    // Compare what the block serializes to, so a delimiter change counts.
+    if (composeNote(fresh, "") !== composeNote(frontmatterBlock, "")) {
       setFrontmatterLines(fresh);
     }
   }
@@ -180,7 +181,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
       : resolveTitle(
           tab.path,
           body,
-          parseNote(composeNote(frontmatterLines, "")).frontmatter.title
+          parseNote(composeNote(frontmatterBlock, "")).frontmatter.title
         );
 
   // Live values behind stable getters, so the mount-frozen editor callbacks
@@ -273,7 +274,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
     (raw: string) => {
       const parsed = parseNote(raw);
 
-      setFrontmatterLines(parsed.rawLines);
+      setFrontmatterLines(parsed.raw);
       setBody(parsed.body);
       setWords(countWords(raw));
       onChange(raw);
@@ -423,7 +424,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
         <SourceEditor
           focusOnMount={active}
           initialCursor={sourceCursor}
-          initialValue={composeNote(frontmatterLines, body)}
+          initialValue={composeNote(frontmatterBlock, body)}
           key={`${reloadKey}:source`}
           onChange={handleSourceChange}
           onReady={attachSourceEditor}

--- a/src/components/workspace/note-session.tsx
+++ b/src/components/workspace/note-session.tsx
@@ -421,6 +421,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
       ) : null}
       {sourceMode ? (
         <SourceEditor
+          focusOnMount={active}
           initialCursor={sourceCursor}
           initialValue={composeNote(frontmatterLines, body)}
           key={`${reloadKey}:source`}

--- a/src/core/frontmatter.spec.ts
+++ b/src/core/frontmatter.spec.ts
@@ -74,8 +74,8 @@ describe("parseNote", () => {
     );
 
     expect(parsed.frontmatter.pinned).toBe(true);
-    expect(parsed.rawLines).toStrictEqual(["pinned: true", "custom: x"]);
-    expect(composeNote(parsed.rawLines, "body\n")).toBe(
+    expect(parsed.raw?.lines).toStrictEqual(["pinned: true", "custom: x"]);
+    expect(composeNote(parsed.raw, "body\n")).toBe(
       "---\npinned: true\ncustom: x\n---\nbody\n"
     );
   });
@@ -148,23 +148,46 @@ describe("updateFrontmatter", () => {
 
 describe("composeNote", () => {
   it("should return the body alone when there is no frontmatter", () => {
-    expect(composeNote([], "# hi\n")).toBe("# hi\n");
+    expect(composeNote(undefined, "# hi\n")).toBe("# hi\n");
   });
 
   it("should wrap raw lines in delimiters", () => {
-    expect(composeNote(["pinned: true", "custom: x"], "body\n")).toBe(
-      "---\npinned: true\ncustom: x\n---\nbody\n"
+    expect(
+      composeNote(
+        { close: "---", lines: ["pinned: true", "custom: x"] },
+        "body\n"
+      )
+    ).toBe("---\npinned: true\ncustom: x\n---\nbody\n");
+  });
+
+  it("should keep an empty block rather than dropping its delimiters", () => {
+    expect(composeNote({ close: "---", lines: [] }, "body\n")).toBe(
+      "---\n---\nbody\n"
     );
   });
 
   it("should round-trip through parseNote with the body replaced", () => {
     const original = "---\npinned: true\ntags: [a]\n---\nold body\n";
     const parsed = parseNote(original);
-    const next = composeNote(parsed.rawLines, "new body\n");
+    const next = composeNote(parsed.raw, "new body\n");
     const reparsed = parseNote(next);
 
     expect(reparsed.frontmatter).toStrictEqual(parsed.frontmatter);
     expect(reparsed.body).toBe("new body\n");
+  });
+
+  it.each([
+    "---\n---\nbody\n",
+    "---\n---\n",
+    "---\n...\nbody\n",
+    "---\npinned: true\n...\nbody\n",
+    "---\npinned: true\ntags: [a]\n---\nbody\n",
+    "---\n\n---\nbody\n",
+    "just a body\n",
+  ])("should round-trip %j byte for byte", (original) => {
+    const parsed = parseNote(original);
+
+    expect(composeNote(parsed.raw, parsed.body)).toBe(original);
   });
 });
 
@@ -221,7 +244,9 @@ describe("retitleFrontmatter", () => {
   ])("should round-trip %j through parseNote", (title) => {
     const lines = retitleFrontmatter(["title: old"], title);
 
-    expect(parseNote(composeNote(lines, "body")).frontmatter.title).toBe(title);
+    expect(
+      parseNote(composeNote({ close: "---", lines }, "body")).frontmatter.title
+    ).toBe(title);
   });
 
   it("should preserve indentation", () => {
@@ -233,8 +258,8 @@ describe("retitleFrontmatter", () => {
   it("should round-trip a colon through parseNote", () => {
     const lines = retitleFrontmatter(["title: old"], "effect: a primer");
 
-    expect(parseNote(composeNote(lines, "body")).frontmatter.title).toBe(
-      "effect: a primer"
-    );
+    expect(
+      parseNote(composeNote({ close: "---", lines }, "body")).frontmatter.title
+    ).toBe("effect: a primer");
   });
 });

--- a/src/core/frontmatter.spec.ts
+++ b/src/core/frontmatter.spec.ts
@@ -96,6 +96,18 @@ describe("updateFrontmatter", () => {
     expect(next).toBe("body\n");
   });
 
+  it("should keep a block that was already empty", () => {
+    expect(updateFrontmatter("---\n---\nbody\n", { pinned: false })).toBe(
+      "---\n---\nbody\n"
+    );
+  });
+
+  it("should keep an already-empty block's ... delimiter", () => {
+    expect(updateFrontmatter("---\n...\nbody\n", { pinned: false })).toBe(
+      "---\n...\nbody\n"
+    );
+  });
+
   it("should preserve unknown keys verbatim", () => {
     const content =
       "---\ncustom: thing\npinned: true\nauthor: someone\n---\nbody\n";

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -22,11 +22,23 @@ interface FrontmatterPatch {
   tags?: string[];
 }
 
+/** A frontmatter block as it was read, so `composeNote` can put it back. */
+export interface RawBlock {
+  /**
+   * The closing delimiter verbatim. `parseNote` accepts `---` and `...`, and
+   * an externally authored note keeps whichever one it used.
+   */
+  close: string;
+  /** The lines between the delimiters. Empty for a `---\n---` block. */
+  lines: string[];
+}
+
 export interface ParsedNote {
   body: string;
   frontmatter: Frontmatter;
-  /** Raw lines of the frontmatter block, without the `---` delimiters. */
-  rawLines: string[];
+  /** Undefined when the file carries no block at all, which is not the same
+   * thing as carrying an empty one. */
+  raw: RawBlock | undefined;
 }
 
 const CLOSING_DELIMITERS = new Set(["---", "..."]);
@@ -161,7 +173,7 @@ export function parseNote(content: string): ParsedNote {
   const fallback: ParsedNote = {
     body: content,
     frontmatter: { pinned: false, tags: [], title: undefined },
-    rawLines: [],
+    raw: undefined,
   };
 
   if (!(content.startsWith("---\n") || content.startsWith("---\r\n"))) {
@@ -179,9 +191,9 @@ export function parseNote(content: string): ParsedNote {
 
   // CRLF files leave a trailing \r on every split line; strip it here so
   // `composeNote`'s \n joins cannot emit a block with mixed line endings.
-  const rawLines = lines
-    .slice(1, closeIndex)
-    .map((line) => line.replace(TRAILING_CR, ""));
+  const strip = (line: string) => line.replace(TRAILING_CR, "");
+  const rawLines = lines.slice(1, closeIndex).map(strip);
+  const close = strip(lines[closeIndex] ?? "---");
   const body = lines.slice(closeIndex + 1).join("\n");
   const frontmatter: Frontmatter = {
     pinned: false,
@@ -207,7 +219,7 @@ export function parseNote(content: string): ParsedNote {
 
   frontmatter.tags = [...new Set(frontmatter.tags)];
 
-  return { body, frontmatter, rawLines };
+  return { body, frontmatter, raw: { close, lines: rawLines } };
 }
 
 /** Drops the `pinned`/`tags` lines (and tag list items) from a raw block. */
@@ -279,13 +291,18 @@ export function retitleFrontmatter(rawLines: string[], title: string) {
   return rawLines.with(index, `${indent}title: ${serializeTitle(title)}`);
 }
 
-/** Reassemble a full note file from raw frontmatter lines and a body. */
-export function composeNote(rawLines: string[], body: string) {
-  if (rawLines.length === 0) {
+/**
+ * Reassemble a full note file: the inverse of `parseNote`. A file with no block
+ * is body alone, and an empty block is still a block.
+ */
+export function composeNote(raw: RawBlock | undefined, body: string) {
+  if (raw === undefined) {
     return body;
   }
 
-  return `---\n${rawLines.join("\n")}\n---\n${body}`;
+  const block = raw.lines.map((line) => `${line}\n`).join("");
+
+  return `---\n${block}${raw.close}\n${body}`;
 }
 
 /**
@@ -306,7 +323,7 @@ export function updateFrontmatter(
     tags: patch.tags ?? parsed.frontmatter.tags,
   };
 
-  const foreignLines = withoutOwnKeys(parsed.rawLines);
+  const foreignLines = withoutOwnKeys(parsed.raw?.lines ?? []);
 
   const ownLines: string[] = [];
 
@@ -330,5 +347,10 @@ export function updateFrontmatter(
     return parsed.body;
   }
 
-  return `---\n${blockLines.join("\n")}\n---\n${parsed.body}`;
+  return composeNote(
+    // A block this rewrites keeps the delimiter the file used; one it creates
+    // gets the `---` notras authors.
+    { close: parsed.raw?.close ?? "---", lines: blockLines },
+    parsed.body
+  );
 }

--- a/src/core/frontmatter.ts
+++ b/src/core/frontmatter.ts
@@ -342,15 +342,17 @@ export function updateFrontmatter(
   }
 
   const blockLines = [...ownLines, ...foreignLines];
+  const arrivedEmpty =
+    parsed.raw !== undefined && parsed.raw.lines.length === 0;
 
-  if (blockLines.length === 0) {
-    return parsed.body;
-  }
+  // Removing the block is for one this update emptied. A block that arrived
+  // empty had no owned keys to remove, so `---\n---` survives a no-op patch.
+  // A block this rewrites keeps the delimiter the file used; one it creates
+  // gets the `---` notras authors.
+  const raw =
+    blockLines.length === 0 && !arrivedEmpty
+      ? undefined
+      : { close: parsed.raw?.close ?? "---", lines: blockLines };
 
-  return composeNote(
-    // A block this rewrites keeps the delimiter the file used; one it creates
-    // gets the `---` notras authors.
-    { close: parsed.raw?.close ?? "---", lines: blockLines },
-    parsed.body
-  );
+  return composeNote(raw, parsed.body);
 }

--- a/src/server/services/note-service.ts
+++ b/src/server/services/note-service.ts
@@ -201,7 +201,10 @@ const makeNoteService = Effect.gen(function* () {
     const file = yield* fileStore.read(path);
     const parsed = parseNote(file.content);
     const next = composeNote(
-      retitleFrontmatter(parsed.rawLines, title),
+      parsed.raw && {
+        ...parsed.raw,
+        lines: retitleFrontmatter(parsed.raw.lines, title),
+      },
       retitleLeadingHeading(parsed.body, title)
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting for Markdown frontmatter, including YAML fields and supported delimiters.
  * Editors can now optionally focus automatically when opened.

* **Bug Fixes**
  * Preserved frontmatter formatting, delimiters, and empty blocks when editing or saving notes.
  * Improved caret placement for editors opened in the background without disrupting the current focus.

* **Tests**
  * Added coverage for frontmatter highlighting, round-trip preservation, and editor focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->