### PR TITLE
feat: ✨ make draggable tabs feel alive

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1566,3 +1566,37 @@ editing a note on open.
 
 **Constraint:** markdown cannot express bold over part of a span, so that saves
 as `` `**hello** world` ``, literal markers inside it.
+
+### D57 A tab drag is dnd-kit's, and reorders on release
+
+`TabStrip` wraps the tablist in dnd-kit's `DndContext` and `SortableContext`,
+each `TabItem` calls `useSortable`, and `moveTab` runs once from `onDragEnd`.
+The strip used to hand-roll the drag on pointer events and call `moveTab` on
+every crossing, so the tab teleported into its new slot and each crossing
+re-rendered the workspace and rewrote `localStorage` mid-press.
+
+**Rejected: keeping the hand-rolled drag and adding a FLIP pass to it.** About
+300 lines against 45, and its one advantage was a pure index-math function with
+a spec, where dnd-kit's equivalent needs a layout engine `happy-dom` does not
+have.
+
+**Rejected: every library built on the HTML5 drag-and-drop API,**
+`@atlaskit/pragmatic-drag-and-drop` foremost. `tauri.conf.json` sets
+`dragDropEnabled`, which turns DOM drag-drop off and is what lets
+`onDragDropEvent` take a file dropped into a note. dnd-kit's `PointerSensor`
+needs neither. Also rejected: `@dnd-kit/react` 0.5.0 (beta), `motion`'s
+`Reorder` (spring-first), `sortablejs` (moves nodes itself, against `D56`'s
+keys).
+
+**Constraint:** `useSortable`'s `attributes` are not spread and no keyboard
+sensor is installed, because they carry a `role` and `tabIndex` that would
+overwrite what `D37` set. The drag handle is the label button, so the close
+button beside it does not start a drag.
+
+**Constraint:** the tablist is `relative` and the overflow measure reads
+`offsetLeft` against it. A transformed tab has a rect outside its slot, and the
+measure would count it as scrolled out of view for the length of a slide.
+
+**Constraint:** `@dnd-kit/core` 6.3.1 and `@dnd-kit/sortable` 10.0.0 were last
+published in December 2024 and the successor is the beta above, so this is a
+dependency that will not move.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -194,12 +194,14 @@ animation, no entrance choreography beyond the platform's own, and no spring.
 - Focus mode fades non-active blocks to `0.28` opacity over `0.3s`.
 - Hover affordances (code block toolbar, code block buttons, wikilinks) resolve
   over `0.15s`.
+- A dragged tab follows the pointer, and the tabs it crosses slide one place
+  over `0.15s`, as does the released tab and one that ⌘⌥⇧←/→ moves (`D57`).
 - Dialogs, tooltips, and the tag combobox fade, scale, and slide on open and
   close. This is macOS behaviour for a sheet, and it is the reason the backdrop
   blurs too.
 - Shadcn primitives carry their own hover and press transitions, and the toast
-  spinner spins. Beyond those, `src/styles.css` animates only focus mode,
-  wikilinks, and the code-block toolbar and its buttons.
+  spinner spins. Beyond those and the tab strip, `src/styles.css` animates only
+  focus mode, wikilinks, and the code-block toolbar and its buttons.
 - The window does not bounce. `html` sets `overscroll-behavior: none`, so a
   flick past the end of a note stays in the note rather than chaining into the
   document and dragging the titlebar, the tab strip and the status strip with
@@ -207,7 +209,8 @@ animation, no entrance choreography beyond the platform's own, and no spring.
   does.
 
 `prefers-reduced-motion: reduce` collapses all of it. Every animation above has
-a real non-motion end state, so removing the transition costs nothing.
+a real non-motion end state, so removing the transition costs nothing. A dragged
+tab still follows the pointer, which is manipulation rather than a transition.
 
 ## Interaction and state
 
@@ -274,7 +277,8 @@ a real non-motion end state, so removing the transition costs nothing.
   the band's bottom hairline, so it reads as continuous with the note below.
   Tabs divide the strip evenly over a `min-w-24` floor and scroll past it, so a
   lone tab spans the window. An external file's tab is mono, the way its path
-  was. The save glyph and the pin
+  was. A dragged tab takes a shadow and paints over the tabs it crosses (`D57`).
+  The save glyph and the pin
   sit after the strip and follow the active tab.
 - **The palette is the action surface.** A new note-level action goes in ⌘K
   rather than into new chrome. `ARCHITECTURE.md` lists what it holds.

--- a/SPEC.md
+++ b/SPEC.md
@@ -47,8 +47,9 @@ walkthrough is their only coverage. Run it under `pnpm dev`.
 - [ ] 19. Click each tab in turn, including one that is not next to the active
       one → each shows its note; click a tab's × → the neighbour takes over
       rather than the tab merely being selected
-- [ ] 19b. Drag a tab past its neighbour → the strip reorders under the pointer
-      and stays put on release; ⌘⌥⇧← moves it back; press a tab and jiggle
+- [ ] 19b. Drag a tab past its neighbour → it follows the pointer under a
+      shadow, the neighbour slides aside, and it settles on release; ⌘⌥⇧←
+      slides it back; Escape mid-drag returns every tab; press a tab and jiggle
       inside its own bounds → it selects and does not reorder
 - [ ] 20. ⌘W → the tab to the right takes over; ⌘⇧T → it comes back where it
       was; ⌘W on the last remaining tab leaves the empty state, and the tab

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "10.0.0",
     "@fontsource-variable/literata": "5.3.0",
     "@fontsource/ia-writer-mono": "5.3.0",
     "@tanstack/react-router": "1.170.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@base-ui/react':
         specifier: 1.7.0
         version: 1.7.0(@types/react@19.2.18)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/sortable':
+        specifier: 10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/literata':
         specifier: 5.3.0
         version: 5.3.0
@@ -429,6 +435,28 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.75.1':
     resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
@@ -4007,6 +4035,31 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.75.1':
     dependencies:

--- a/src/components/tabs/tab-strip.tsx
+++ b/src/components/tabs/tab-strip.tsx
@@ -1,6 +1,26 @@
+import type {
+  Announcements,
+  DragEndEvent,
+  DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  closestCenter,
+  DndContext,
+  MeasuringStrategy,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { AnimateLayoutChanges } from "@dnd-kit/sortable";
+import {
+  defaultAnimateLayoutChanges,
+  horizontalListSortingStrategy,
+  SortableContext,
+  useSortable,
+} from "@dnd-kit/sortable";
 import { getRouteApi } from "@tanstack/react-router";
 import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -43,6 +63,34 @@ const STEPS: Record<string, TabStep> = {
   Home: "start",
 };
 
+const ACTIVATION_DISTANCE_PX = 4;
+
+/** dnd-kit defaults to 250ms; `DESIGN.md` names 0.15s for chrome. */
+const TAB_TRANSITION = { duration: 150, easing: "ease" };
+
+function draggedLabel(data: Record<string, unknown> | undefined) {
+  return typeof data?.label === "string" ? data.label : "";
+}
+
+/** dnd-kit's defaults announce the minted id (`D56`). */
+const ANNOUNCEMENTS: Announcements = {
+  onDragCancel: ({ active }) =>
+    `left ${draggedLabel(active.data.current)} where it was`,
+  onDragEnd: ({ active, over }) =>
+    over === null
+      ? `left ${draggedLabel(active.data.current)} where it was`
+      : `dropped ${draggedLabel(active.data.current)} on ${draggedLabel(over.data.current)}`,
+  onDragOver: ({ active, over }) =>
+    over === null
+      ? undefined
+      : `${draggedLabel(active.data.current)} is over ${draggedLabel(over.data.current)}`,
+  onDragStart: ({ active }) => `picked up ${draggedLabel(active.data.current)}`,
+};
+
+/** Also animate an order change no drag made, which is what `⌘⌥⇧←/→` does. */
+const animateLayoutChanges: AnimateLayoutChanges = (args) =>
+  args.isSorting || args.wasDragging ? defaultAnimateLayoutChanges(args) : true;
+
 interface TabItemProps {
   active: boolean;
   /** Shown until the session publishes a title off its live buffer. */
@@ -53,8 +101,21 @@ interface TabItemProps {
 function TabItem({ active, fallback, tab }: TabItemProps) {
   const id = tabId(tab);
   const snapshot = useTabSnapshot(id);
-  const ref = useRef<HTMLSpanElement>(null);
+  const ref = useRef<HTMLSpanElement | null>(null);
   const label = snapshot?.title ?? fallback;
+  const {
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({
+    animateLayoutChanges,
+    data: { label },
+    id,
+    transition: TAB_TRANSITION,
+  });
 
   // Keyboard switching can land on a tab that is scrolled out of the strip.
   useEffect(() => {
@@ -63,9 +124,26 @@ function TabItem({ active, fallback, tab }: TabItemProps) {
     }
   }, [active]);
 
+  const setRefs = useCallback(
+    (node: HTMLSpanElement | null) => {
+      ref.current = node;
+      setNodeRef(node);
+    },
+    [setNodeRef]
+  );
+
   const select = useCallback(() => {
     activateTab(id);
   }, [id]);
+
+  /** A press selects, the way a native tab does, before any drag begins. */
+  const startPress = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      select();
+      listeners?.onPointerDown?.(event);
+    },
+    [listeners, select]
+  );
 
   const close = useCallback(() => {
     closeTab(id);
@@ -96,11 +174,22 @@ function TabItem({ active, fallback, tab }: TabItemProps) {
               "no-drag group flex h-full min-w-24 flex-1 basis-0 items-center border-border border-r ps-2.5 pe-1",
               active
                 ? "bg-background text-foreground"
-                : "text-muted-foreground hover:bg-muted/40"
+                : "text-muted-foreground hover:bg-muted/40",
+              isDragging &&
+                "z-10 cursor-grabbing shadow-[0_2px_8px_rgb(0_0_0/0.18)]"
             )}
             data-tab-id={id}
-            ref={ref}
+            ref={setRefs}
             role="presentation"
+            style={{
+              // By hand rather than dnd-kit's `CSS` helper, whose export would
+              // shadow the global `CSS.escape` the strip uses below.
+              transform:
+                transform === null
+                  ? undefined
+                  : `translate3d(${transform.x}px, 0, 0)`,
+              transition,
+            }}
           />
         }
       >
@@ -118,6 +207,9 @@ function TabItem({ active, fallback, tab }: TabItemProps) {
           )}
           id={tabButtonId(id)}
           onClick={select}
+          // The handle, so the close button beside it never starts a drag.
+          onPointerDown={startPress}
+          ref={setActivatorNodeRef}
           role="tab"
           tabIndex={active ? 0 : -1}
           type="button"
@@ -208,16 +300,20 @@ interface TabStripProps {
  * The open tabs, in the title bar where the note's title used to sit (`D52`).
  *
  * One tab stop with arrow keys inside it, the `ToggleGroup` pattern `D37` set.
+ * Dragging one is dnd-kit's, and `D57` carries why.
  */
 export function TabStrip({ activeId, onNew, tabs }: TabStripProps) {
   const { notes } = rootApi.useLoaderData();
   const listRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<null | {
-    captured: boolean;
-    id: string;
-    pointerId: number;
-  }>(null);
   const [hidden, setHidden] = useState<string[]>([]);
+  const ids = useMemo(() => tabs.map(tabId), [tabs]);
+  // No keyboard sensor: it wants the `attributes` spread, which would overwrite
+  // the `role="tab"` wiring, and `⌘⌥⇧←/→` already reorders (`D57`).
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: ACTIVATION_DISTANCE_PX },
+    })
+  );
 
   const labelFor = useCallback(
     (tab: Tab) =>
@@ -236,15 +332,16 @@ export function TabStrip({ activeId, onNew, tabs }: TabStripProps) {
     }
 
     const measure = () => {
-      const bounds = list.getBoundingClientRect();
-      const open = new Set(tabs.map(tabId));
+      const open = new Set(ids);
 
       const next = [...list.querySelectorAll<HTMLElement>("[data-tab-id]")]
-        .filter((item) => {
-          const rect = item.getBoundingClientRect();
-
-          return rect.right <= bounds.left + 1 || rect.left >= bounds.right - 1;
-        })
+        .filter(
+          (item) =>
+            // Not a rect: a drag transforms a tab out of its slot, and a rect
+            // would call it hidden for being mid-slide.
+            item.offsetLeft + item.offsetWidth <= list.scrollLeft + 1 ||
+            item.offsetLeft >= list.scrollLeft + list.clientWidth - 1
+        )
         .map((item) => item.dataset.tabId ?? "")
         // A tab closed between the measurement and this frame still has a
         // node until React commits.
@@ -270,7 +367,7 @@ export function TabStrip({ activeId, onNew, tabs }: TabStripProps) {
       observer.disconnect();
       list.removeEventListener("scroll", measure);
     };
-  }, [tabs]);
+  }, [ids]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -299,104 +396,54 @@ export function TabStrip({ activeId, onNew, tabs }: TabStripProps) {
     [activeId, tabs]
   );
 
-  /**
-   * A press selects, which also keeps selection off the click path: a pointer
-   * capture retargets the `click` it derives to the capturing element, so an
-   * `onClick` inside would not fire once a drag had claimed the pointer.
-   */
-  const handlePointerDown = useCallback((event: React.PointerEvent) => {
-    const element = event.target as HTMLElement;
-    const id = element.closest<HTMLElement>("[data-tab-id]")?.dataset.tabId;
-
-    // The close button owns its own press.
-    if (
-      event.button !== 0 ||
-      id === undefined ||
-      element.closest("[data-tab-close]") !== null
-    ) {
-      return;
-    }
-
-    dragRef.current = { captured: false, id, pointerId: event.pointerId };
-    activateTab(id);
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    activateTab(String(event.active.id));
   }, []);
 
-  /**
-   * Pointer events rather than HTML5 drag, which the titlebar's
-   * `-webkit-app-region: drag` intercepts. Capture waits until the press has
-   * crossed into another tab: claiming it on the way down takes the close
-   * button's click with it.
-   */
-  const handlePointerMove = useCallback((event: React.PointerEvent) => {
-    const drag = dragRef.current;
-    const list = listRef.current;
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
 
-    if (drag === null || drag.pointerId !== event.pointerId || list === null) {
-      return;
-    }
+      if (over === null || active.id === over.id) {
+        return;
+      }
 
-    // A press released outside the strip sends its `pointerup` elsewhere, so
-    // the drag would still be armed when the same pointer next hovers through.
-    if (event.buttons === 0) {
-      dragRef.current = null;
-
-      return;
-    }
-
-    const bounds = list.getBoundingClientRect();
-
-    if (event.clientY < bounds.top || event.clientY > bounds.bottom) {
-      return;
-    }
-
-    const items = [...list.querySelectorAll<HTMLElement>("[data-tab-id]")];
-    const over = items.findIndex((item) => {
-      const rect = item.getBoundingClientRect();
-
-      return event.clientX >= rect.left && event.clientX <= rect.right;
-    });
-
-    if (over === -1 || items[over]?.dataset.tabId === drag.id) {
-      return;
-    }
-
-    if (!drag.captured) {
-      drag.captured = true;
-      list.setPointerCapture(event.pointerId);
-    }
-
-    moveTab(drag.id, over);
-  }, []);
-
-  const endDrag = useCallback((event: React.PointerEvent) => {
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-
-    dragRef.current = null;
-  }, []);
+      moveTab(String(active.id), ids.indexOf(String(over.id)));
+    },
+    [ids]
+  );
 
   return (
     <div className="flex min-w-0 flex-1 items-stretch self-stretch">
-      <div
-        className="flex min-w-0 flex-1 items-stretch overflow-x-auto"
-        onKeyDown={handleKeyDown}
-        onPointerCancel={endDrag}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={endDrag}
-        ref={listRef}
-        role="tablist"
+      <DndContext
+        accessibility={{ announcements: ANNOUNCEMENTS }}
+        collisionDetection={closestCenter}
+        // What lets `animateLayoutChanges` see a change no drag made.
+        measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+        onDragEnd={handleDragEnd}
+        onDragStart={handleDragStart}
+        sensors={sensors}
       >
-        {tabs.map((tab) => (
-          <TabItem
-            active={tabId(tab) === activeId}
-            fallback={labelFor(tab)}
-            key={tabId(tab)}
-            tab={tab}
-          />
-        ))}
-      </div>
+        <SortableContext items={ids} strategy={horizontalListSortingStrategy}>
+          <div
+            // `relative` so a tab's `offsetParent` is the strip, which the
+            // measure above reads against.
+            className="relative flex min-w-0 flex-1 items-stretch overflow-x-auto"
+            onKeyDown={handleKeyDown}
+            ref={listRef}
+            role="tablist"
+          >
+            {tabs.map((tab) => (
+              <TabItem
+                active={tabId(tab) === activeId}
+                fallback={labelFor(tab)}
+                key={tabId(tab)}
+                tab={tab}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
       <OverflowMenu
         hidden={tabs.filter((tab) => hidden.includes(tabId(tab)))}
         labelFor={labelFor}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tab dragging with smoother animations and visual feedback.
  * Tabs now shift as you drag, display a shadow, and reorder when dragging ends.
  * Pressing Escape during a drag restores the original tab order.
  * Reduced-motion settings disable animations while preserving drag functionality.
* **Documentation**
  * Updated tab interaction and verification guidance to reflect the improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->