### PR TITLE
feat: ✨ single tab now drags window

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1600,3 +1600,13 @@ measure would count it as scrolled out of view for the length of a slide.
 **Constraint:** `@dnd-kit/core` 6.3.1 and `@dnd-kit/sortable` 10.0.0 were last
 published in December 2024 and the successor is the beta above, so this is a
 dependency that will not move.
+
+**Constraint:** one tab has nowhere to go, so `useSortable` takes
+`disabled: sole` and the tab carries `data-tauri-drag-region` instead. dnd-kit
+drops its listeners when disabled, and Tauri's injected handler treats a
+`button` that carries the attribute as a drag region, so the press moves the
+window the way the rest of the titlebar does. That reverses `D28`'s no-drag
+exemption for one element under one condition. It also means the sole tab
+inherits macOS titlebar behaviour whole: a double-click on it zooms the window,
+and Tauri's `preventDefault` on the mousedown leaves the button unfocused after
+a click.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -226,7 +226,9 @@ tab still follows the pointer, which is manipulation rather than a transition.
   `src/components/titlebar.tsx` is the only place the drag region is declared,
   and every window and route renders it. Buttons and inputs inside it set
   `no-drag` so they stay clickable, and `.no-drag` is the opt-in for anything
-  else that has to receive the pointer there.
+  else that has to receive the pointer there. A tab with no neighbours opts back
+  out: it carries `data-tauri-drag-region`, so pressing and moving it moves the
+  window rather than the tab (`D57`).
 - **The save state is a glyph, and it sits in the titlebar** (`D35`, `D38`).
   `SaveIndicator` renders between the title and the pin, a floppy carrying a pen
   for `dirty`, no badge for `saving`, a check for `saved`, and a slash for

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -222,13 +222,12 @@ tab still follows the pointer, which is manipulation rather than a transition.
   region rather than in a band of their own, so the window title is the note
   title, resolved by `D32` from frontmatter, a leading `#`, then the
   filename. It is display-only text: renaming a file is a ⌘K action. `Titlebar`
-  in
-  `src/components/titlebar.tsx` is the only place the drag region is declared,
-  and every window and route renders it. Buttons and inputs inside it set
-  `no-drag` so they stay clickable, and `.no-drag` is the opt-in for anything
-  else that has to receive the pointer there. A tab with no neighbours opts back
-  out: it carries `data-tauri-drag-region`, so pressing and moving it moves the
-  window rather than the tab (`D57`).
+  in `src/components/titlebar.tsx` declares the region every window and route
+  renders. Buttons and inputs inside it set `no-drag` so they stay clickable,
+  and `.no-drag` is the opt-in for anything else that has to receive the pointer
+  there. `src/components/tabs/tab-strip.tsx` is the one other declaration: a tab
+  with no neighbours carries `data-tauri-drag-region` of its own, so pressing
+  and moving it moves the window rather than the tab (`D57`).
 - **The save state is a glyph, and it sits in the titlebar** (`D35`, `D38`).
   `SaveIndicator` renders between the title and the pin, a floppy carrying a pen
   for `dirty`, no badge for `saving`, a check for `saved`, and a slash for

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,6 +51,9 @@ walkthrough is their only coverage. Run it under `pnpm dev`.
       shadow, the neighbour slides aside, and it settles on release; ⌘⌥⇧←
       slides it back; Escape mid-drag returns every tab; press a tab and jiggle
       inside its own bounds → it selects and does not reorder
+- [ ] 19c. Close down to one tab and drag it → the window moves and the tab
+      stays put, taking no shadow; double-click it → the window zooms; its ×,
+      its context menu, and a second tab's drag all still behave
 - [ ] 20. ⌘W → the tab to the right takes over; ⌘⇧T → it comes back where it
       was; ⌘W on the last remaining tab leaves the empty state, and the tab
       context menu's close agrees with both

--- a/src/components/tabs/tab-strip.tsx
+++ b/src/components/tabs/tab-strip.tsx
@@ -95,10 +95,12 @@ interface TabItemProps {
   active: boolean;
   /** Shown until the session publishes a title off its live buffer. */
   fallback: string;
+  /** The only tab has nowhere to go, so its press moves the window instead. */
+  sole: boolean;
   tab: Tab;
 }
 
-function TabItem({ active, fallback, tab }: TabItemProps) {
+function TabItem({ active, fallback, sole, tab }: TabItemProps) {
   const id = tabId(tab);
   const snapshot = useTabSnapshot(id);
   const ref = useRef<HTMLSpanElement | null>(null);
@@ -113,6 +115,7 @@ function TabItem({ active, fallback, tab }: TabItemProps) {
   } = useSortable({
     animateLayoutChanges,
     data: { label },
+    disabled: sole,
     id,
     transition: TAB_TRANSITION,
   });
@@ -179,6 +182,7 @@ function TabItem({ active, fallback, tab }: TabItemProps) {
                 "z-10 cursor-grabbing shadow-[0_2px_8px_rgb(0_0_0/0.18)]"
             )}
             data-tab-id={id}
+            data-tauri-drag-region={sole || undefined}
             ref={setRefs}
             role="presentation"
             style={{
@@ -205,6 +209,7 @@ function TabItem({ active, fallback, tab }: TabItemProps) {
             "min-w-0 flex-1 truncate text-start text-sm",
             tab.kind === "external" && "font-mono text-xs"
           )}
+          data-tauri-drag-region={sole || undefined}
           id={tabButtonId(id)}
           onClick={select}
           // The handle, so the close button beside it never starts a drag.
@@ -300,7 +305,8 @@ interface TabStripProps {
  * The open tabs, in the title bar where the note's title used to sit (`D52`).
  *
  * One tab stop with arrow keys inside it, the `ToggleGroup` pattern `D37` set.
- * Dragging one is dnd-kit's, and `D57` carries why.
+ * Dragging one is dnd-kit's, and `D57` carries why. A lone tab has nowhere to
+ * go, so it hands the press to the window instead.
  */
 export function TabStrip({ activeId, onNew, tabs }: TabStripProps) {
   const { notes } = rootApi.useLoaderData();
@@ -438,6 +444,7 @@ export function TabStrip({ activeId, onNew, tabs }: TabStripProps) {
                 active={tabId(tab) === activeId}
                 fallback={labelFor(tab)}
                 key={tabId(tab)}
+                sole={tabs.length === 1}
                 tab={tab}
               />
             ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-tab windows can now be dragged using the tab area.
  * Double-clicking the single tab zooms the window.

* **Bug Fixes**
  * Prevented single tabs from triggering unnecessary sorting behavior.
  * Preserved tab closing, context menu, and multi-tab drag interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->