### PR TITLE
refactor: 🔄 use tanstack query for reads & writes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,7 +169,7 @@ Nothing enforces these. Lint held them until `D41` retired the ESLint config, an
 
 The UI calls plain async functions in `src/data/`, one concern per file. They validate with Effect Schema where the input is user-shaped, and run effects via `run()` from `src/data/run.ts`, the only place `AppRuntime` is executed. `run()` unwraps typed failures into plain `Error`s, so a caller can write `toast.add({ title: error.message, type: "error" })`.
 
-Reads reach those functions through TanStack Query. `src/data/queries.ts` is the only place a query key or a set of query options is written: `noteQueries` for everything a note write can affect, `notesDirQuery` for the folder that settings owns. Its keys run generic to specific, so every invalidation the app performs is one prefix, and `D66` carries the rest. Writes stay direct calls, because the cache holds reads and `D31` and `D54` own the write chains.
+Reads reach those functions through TanStack Query. `src/data/queries.ts` is the only place a key over `src/data` is written: `noteQueries` for everything a note write can affect, `notesDirQuery` for the folder that settings owns. A query over something else, such as the launch-at-login switch the OS owns, is keyed beside the component that shows it. Its keys run generic to specific, so every invalidation the app performs is one prefix, and `D66` carries the rest. Writes stay direct calls, with one exception: `useNoteTags` goes through a mutation whose scope is the note's path, which is what serializes the two surfaces `D31` allows (`D67`). `useAutosave` keeps its own chain (`D54`).
 
 ### Effect style
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,7 @@ How notras is built. `AGENTS.md` maps the rest of the docs.
 | Layer           | Choice                                                                                                       |
 | --------------- | ------------------------------------------------------------------------------------------------------------ |
 | Shell           | Tauri 2 (Rust): file IO commands, FTS5 index, notify watcher, tray, global shortcuts                         |
-| Frontend        | Vite + React 19 + TanStack Router (file routes, no SSR)                                                      |
+| Frontend        | Vite + React 19 + TanStack Router (file routes, no SSR); TanStack Query caches every read (`D66`)            |
 | Editor          | TipTap 3 WYSIWYG + official `@tiptap/markdown` (bidirectional GFM); lowlight code blocks; ⌘P raw-source view |
 | Effect          | Effect 4 (`4.0.0-rc.x`, pinned exactly): typed errors, Layer/DI, `Context.Service`, ManagedRuntime           |
 | Index queries   | Drizzle ORM `sqlite-proxy`, SELECT-only                                                                      |
@@ -24,7 +24,8 @@ Notes are `.md` or `.markdown` files under the notes dir (default `~/notras`). F
 ```mermaid
 flowchart TD
     subgraph webview [Tauri webview]
-        UI[React + TanStack Router] --> Data[src/data async fns]
+        UI[React + TanStack Router] --> Query[TanStack Query cache]
+        Query --> Data[src/data async fns]
         Data --> Services[Effect services]
         Services --> FileStore[FileStore port]
         Services --> Index[Database port, read-only]
@@ -46,7 +47,7 @@ flowchart TD
 
 **Rust is the single writer of the index.** Every TypeScript mutation goes through a Rust command (`write_note`, `rename_note`, `delete_note`, and the rest) that writes the file and updates the index in the same call, then emits `notes-changed`. The `db_select` command rejects anything that is not SELECT/WITH, gated on SQLite's own `sqlite3_stmt_readonly` so a writable `WITH ... DELETE` CTE cannot pass the prefix test. There is no index write path from TypeScript.
 
-**External writers** (AI agents, other editors, git) are reconciled by the debounced watcher. The mtime skip in `index_file` keeps self-writes from echoing. UI refresh is event-driven: the root route listens for `notes-changed` and calls `router.invalidate()`.
+**External writers** (AI agents, other editors, git) are reconciled by the debounced watcher. The mtime skip in `index_file` keeps self-writes from echoing. UI refresh is event-driven: the root route listens for `notes-changed` and invalidates the query keys the event names, so only the tabs holding a changed file re-read (`D66`).
 
 **The index is disposable.** `ensure_schema` runs CREATE IF NOT EXISTS plus FTS5 on startup, so deleting `.notras/index.db` triggers a rebuild. There is no drizzle-kit, no migration directory, and no `db:push`.
 
@@ -83,8 +84,8 @@ src/
   styles.spec.ts      # contrast gate, task-list ladder, note surface,
                       # launch background
   routes/             # TanStack Router file routes
-    __root.tsx        # loader (notes/folders/tags/notesDir), palette, settings
-                      # dialog, hotkeys, notes-changed listener
+    __root.tsx        # loader primes the cache, palette, settings dialog,
+                      # hotkeys, notes-changed listener
     index.tsx         # THE page: the workspace -- tab strip, every open
                       # tab's session, and the two bands (D53)
   components/
@@ -105,6 +106,7 @@ src/
     errors.ts         # DatabaseError, FileError
     fts-markers.ts    # [[hl]] snippet markers shared with SQL
   data/               # Plain async fns the UI calls (ex-server-actions)
+    queries.ts        # THE query keys and options, one factory (D66)
     run.ts            # THE Effect boundary: AppRuntime.runPromiseExit wrapper
   server/
     adapters/         # the only note IO and SQL path to @tauri-apps/*;
@@ -166,6 +168,8 @@ Nothing enforces these. Lint held them until `D41` retired the ESLint config, an
 ### Data access
 
 The UI calls plain async functions in `src/data/`, one concern per file. They validate with Effect Schema where the input is user-shaped, and run effects via `run()` from `src/data/run.ts`, the only place `AppRuntime` is executed. `run()` unwraps typed failures into plain `Error`s, so a caller can write `toast.add({ title: error.message, type: "error" })`.
+
+Reads reach those functions through TanStack Query. `src/data/queries.ts` is the only place a query key or a set of query options is written: `noteQueries` for everything a note write can affect, `notesDirQuery` for the folder that settings owns. Its keys run generic to specific, so every invalidation the app performs is one prefix, and `D66` carries the rest. Writes stay direct calls, because the cache holds reads and `D31` and `D54` own the write chains.
 
 ### Effect style
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -800,6 +800,8 @@ Every read goes through TanStack Query. `src/data/queries.ts` holds one `noteQue
 
 **Constraint:** an external tab's `refetchOnWindowFocus` is `"always"`, not `true`. `shouldFetchOn` reads `value === "always" || (value !== false && isStale(query, options))`, so under an infinite `staleTime` a plain `true` asks a staleness question the query can never answer yes to, and the one refresh path an external tab has would never fire.
 
+**Constraint:** the `/` loader's launch seed is the one read that stays a direct call. It asks for the most recently updated note once per launch to decide which tab opens, and caching a single-row answer nobody reads again would put a key in the cache to serve a decision already made.
+
 **Constraint:** a disabled query still reads its cache entry. A key standing for "nothing to ask" must not collide with one that holds data, which is why the palette returns its own recent slice rather than whatever `enabled: false` handed back.
 
 **Constraint:** an external tab refetches on window focus. Its path lies outside the notes dir, so no payload will ever name it and invalidation cannot reach it.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6,7 +6,7 @@ This file is a log, not a set of rules. An entry records what was decided and wh
 
 A **Constraint:** line reads closest to an order and is not one. It names what the decision left the codebase carrying, and it holds only as long as that decision does.
 
-Numbering is monotonic and IDs are never reused, even after an entry is removed. A citation in a commit or a comment outlives the line it points at, so reusing an ID repoints every reference to it without any of them changing. The highest number issued so far is 66, and some entries below it were removed, so the next entry takes 67.
+Numbering is monotonic and IDs are never reused, even after an entry is removed. A citation in a commit or a comment outlives the line it points at, so reusing an ID repoints every reference to it without any of them changing. The highest number issued so far is 67, and some entries below it were removed, so the next entry takes 68.
 
 An entry belongs here when picking one option ruled out another for a reason worth recording. A rule that must hold, with no competing option anyone would weigh, is an invariant and lives in `ARCHITECTURE.md`.
 
@@ -803,3 +803,21 @@ Every read goes through TanStack Query. `src/data/queries.ts` holds one `noteQue
 **Constraint:** a disabled query still reads its cache entry. A key standing for "nothing to ask" must not collide with one that holds data, which is why the palette returns its own recent slice rather than whatever `enabled: false` handed back.
 
 **Constraint:** an external tab refetches on window focus. Its path lies outside the notes dir, so no payload will ever name it and invalidation cannot reach it.
+
+### D67 A mutation scope serializes a note's tag writes
+
+`useNoteTags` writes through `useMutation` carrying `scope: { id: path }` and `mutationKey: ["note-tags", path]`. The promise queue, the request counter, and the ref holding the last set known to be on disk are gone. `mutationCache.canRun` starts a mutation only when it is the first pending one in its scope, so the scope is what makes the last call the last write. The optimistic list stays in the hook, adjusted during render against the tags coming back from disk.
+
+The queue it replaces belonged to the hook instance, and `D31` puts tag editing on two surfaces. The status strip and the palette therefore held separate queues and did not serialize against each other at all, which the scope fixes by keying on the note instead.
+
+**Rejected: reading the displayed value from `mutation.variables`.** It deletes the optimistic list outright. Rejected because the value stops being pending the moment the write resolves, while the truth arrives a full IPC round trip later through `notes-changed` and the re-read, so the row flashes back to the old set and forward again. That is the failure that ruled out `useOptimistic` in `D66`.
+
+**Rejected: patching the cache in `onMutate`,** which is the canonical optimistic shape and would remove the local list honestly. Rejected on reach: tags render from `noteQueries.file` and from every `noteQueries.list` variant the palette holds, so one toggle would have to find and rewrite the note inside each cached list.
+
+**Rejected: converting `useAutosave` the same way.** Attempted and abandoned. `use-debounce`'s `flushOnExit` fires only when a debounced call is pending, where the hook's unmount flush also has to carry a buffer left behind by a failed write, so the library covers strictly less than the code it would replace and keeping both is two mechanisms for one job. `dirty` also has no `MutationStatus`, because it describes the buffer rather than a request.
+
+**Rejected: a mutation for the launch-at-login switch.** Built and reverted. `onMutate`, `onSettled`, a scope, and a wrapper for the second argument Base UI passes its change handler came to 22 lines against the 11-line `try`/`catch` they replaced. The read moved to a query and stayed there; the write did not.
+
+**Constraint:** a rollback asks `isMutating({ mutationKey })` rather than counting requests itself. `onError` runs before the failure is dispatched, so the failing mutation still counts as pending, and a total above one means a later toggle is queued behind it. `D31` requires that superseded failure to leave the display alone.
+
+**Constraint:** the optimistic list stays in the hook. It is what covers the gap between a write resolving and the re-read landing, which no mutation state spans.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6,7 +6,7 @@ This file is a log, not a set of rules. An entry records what was decided and wh
 
 A **Constraint:** line reads closest to an order and is not one. It names what the decision left the codebase carrying, and it holds only as long as that decision does.
 
-Numbering is monotonic and IDs are never reused, even after an entry is removed. A citation in a commit or a comment outlives the line it points at, so reusing an ID repoints every reference to it without any of them changing. The highest number issued so far is 65, and some entries below it were removed, so the next entry takes 66.
+Numbering is monotonic and IDs are never reused, even after an entry is removed. A citation in a commit or a comment outlives the line it points at, so reusing an ID repoints every reference to it without any of them changing. The highest number issued so far is 66, and some entries below it were removed, so the next entry takes 67.
 
 An entry belongs here when picking one option ruled out another for a reason worth recording. A rule that must hold, with no competing option anyone would weigh, is an invariant and lives in `ARCHITECTURE.md`.
 
@@ -771,3 +771,35 @@ Tauri ships each package as an npm and crate pair, and `tauri build` errors when
 **Constraint:** Renovate's `lib/data/monorepo.json` carries `tauri` but no `plugins-workspace`, so `group:tauriMonorepo` covers the core pairs and the plugin rule here is a local stand-in for an entry that belongs upstream. It goes stale if Renovate adds one.
 
 **Constraint:** nothing in CI runs the Tauri CLI, so a pair that drifts anyway is caught by `tauri build` on the release tag. `tauri build --ignore-version-mismatches` exists and does not belong in `release.yml`.
+
+### D66 TanStack Query caches the reads, and the change event names what to invalidate
+
+Every read goes through TanStack Query. `src/data/queries.ts` holds one `noteQueries` factory whose keys run generic to specific, so each invalidation the app makes is a single prefix: `["notes"]` for an event that named no paths, `["notes", "index"]` for what the note rows derive, and `["notes", "file", kind, path]` for one tab. `notesDirQuery` sits outside that tree, because the notes folder is settings and no write to a note can move it. The root loader primes the cache and returns nothing, components read through `useSuspenseQuery`, and a tab's file is a `useQuery` that replaced `NoteSession`'s own state, its read effect, and its newest-wins counter. `router.invalidate()` is gone, and so are `subscribeRevision` and `bumpRevision` in `src/lib/tabs/store.ts`.
+
+`write_note` emits `notes-changed` on every save and autosave debounces at 800ms, so typing ran four IPC and SQL round trips and made every mounted tab re-read its file from disk, once per 800ms, for a change that named one file. The event has carried its `paths` since it was written and the webview threw them away.
+
+**Rejected: routing the payload through a hand-rolled readers map.** It was designed in full: `subscribeRevision` keyed by path, `bumpRevision` taking the changed set, and an empty set meaning the whole vault. It adds no dependency and it is a partial version of what a keyed cache already does, leaving the newest-wins counters in `note-session.tsx` and `command-palette.tsx` standing because the reads stay unkeyed.
+
+**Rejected: `@effect-atom/atom-react`.** The option that composes with the Effect layer the rest of the app runs on. Version 0.7.0 peer-depends on `effect: ^3.22.1` and this repo pins `effect@4.0.0-rc.112`, so taking it means a peer override on a 0.x library against a release candidate of its own peer.
+
+**Rejected: keeping the whole-folder fan-out.** One signal and no matching rule, and a tab picks up a frontmatter change even when its own path went unreported. Rejected because typing drives the event, so the cost scales with the number of open tabs while someone writes.
+
+**Rejected: suppressing the event for the app's own write.** It would remove the loader invalidation with it. Quick capture is a second webview writing through the same command (`D20`), and the main window learns of that write from this event and nothing else.
+
+**Rejected: the global `QueryCache` error toast.** TanStack's own guidance guards it with `query.state.data !== undefined`, so only a failed background update reports. That guard silences a first read failing for any reason other than a missing file, which `SPEC.md` requires a toast for.
+
+**Constraint:** an empty `paths` means the whole vault changed. `set_notes_dir` emits one, `reindex_all` emits one for a vault that scanned back empty, and the watcher never emits empty at all. An emit site added later that cannot name what changed emits empty rather than nothing.
+
+**Constraint:** `useLoaderData` is not used for query data. A query read that way never becomes active, which makes it eligible for garbage collection and puts it beyond the reach of invalidation.
+
+**Constraint:** the router's own cache is off through `defaultPreloadStaleTime: 0`, so one cache owns staleness.
+
+**Constraint:** `staleTime` is infinite and `retry` is off. The watcher reports an external write within about a second (`D16`), so staleness here is an event rather than a duration, and three retries with backoff would delay the missing-file failure that closes a deleted note's tab.
+
+**Constraint:** a tab holds its last successful read in a ref and falls back to it. A rename changes the key and a failed read clears the data, and either one would otherwise empty the buffer and remount the editor, which is the loss `D56` exists to prevent and the text `D55` promises to keep. Query's own `placeholderData` covers the pending case alone, because it is gated on a status of `pending` and a key that errors reports `error`.
+
+**Constraint:** an external tab's `refetchOnWindowFocus` is `"always"`, not `true`. `shouldFetchOn` reads `value === "always" || (value !== false && isStale(query, options))`, so under an infinite `staleTime` a plain `true` asks a staleness question the query can never answer yes to, and the one refresh path an external tab has would never fire.
+
+**Constraint:** a disabled query still reads its cache entry. A key standing for "nothing to ask" must not collide with one that holds data, which is why the palette returns its own recent slice rather than whatever `enabled: false` handed back.
+
+**Constraint:** an external tab refetches on window focus. Its path lies outside the notes dir, so no payload will ever name it and invalidation cannot reach it.

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,7 +37,8 @@ What notras does. Every claim below is checkable against a running build, so a c
 ## External changes
 
 - The watcher debounces at 300ms, so a file written by anything else reaches the app within about a second. A note appears in the palette under its own title rather than its filename.
-- A change event makes every open tab re-read its file.
+- A change event names the files that changed, and only the tabs holding one of them re-read. An event naming nothing means the whole vault changed, and every tab re-reads.
+- An external file's path is never named by a change event, so an external tab re-reads when the window regains focus.
 - A buffer reloads only when it is clean, the file is newer than this tab's own last write, and the body differs. The reload remounts the editor, so the caret and the undo history go with it.
 - Frontmatter follows the file whether or not the buffer is clean.
 - A dirty buffer wins. An external edit to a note with unsaved changes is not shown, and the next flush overwrites it.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@dnd-kit/sortable": "10.0.0",
     "@fontsource-variable/literata": "5.3.0",
     "@fontsource/ia-writer-mono": "5.3.0",
+    "@tanstack/react-query": "5.102.8",
     "@tanstack/react-router": "1.170.32",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-autostart": "2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@fontsource/ia-writer-mono':
         specifier: 5.3.0
         version: 5.3.0
+      '@tanstack/react-query':
+        specifier: 5.102.8
+        version: 5.102.8(react@19.2.8)
       '@tanstack/react-router':
         specifier: 1.170.32
         version: 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1171,6 +1174,14 @@ packages:
   '@tanstack/history@1.162.1':
     resolution: {integrity: sha512-DR9t6lfLVdrjgCwpglrR9DR7Ok8/HlXjcOE+goWXF3zyuLUO/ug7vMbSFxTqrQTtbRghJfyhmIZ0S6LhPIy44w==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.102.8':
+    resolution: {integrity: sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==}
+
+  '@tanstack/react-query@5.102.8':
+    resolution: {integrity: sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-router@1.170.32':
     resolution: {integrity: sha512-SIpxvaTKco100a5ZR3ePmArbhtm3XOx+w1dpGYY9gxHDta4iXSKDdQuhLonwJbIMkVJsU1rwXf0UDHMrF/1snw==}
@@ -4586,6 +4597,13 @@ snapshots:
       vite: 8.2.2(@types/node@26.4.0)(jiti@2.7.0)(yaml@2.9.0)
 
   '@tanstack/history@1.162.1': {}
+
+  '@tanstack/query-core@5.102.8': {}
+
+  '@tanstack/react-query@5.102.8(react@19.2.8)':
+    dependencies:
+      '@tanstack/query-core': 5.102.8
+      react: 19.2.8
 
   '@tanstack/react-router@1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:

--- a/src/app-shell.tsx
+++ b/src/app-shell.tsx
@@ -1,10 +1,25 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 
 import { CaptureWindow } from "@/components/capture-window";
 import { routeTree } from "@/routeTree.gen";
 
+/** The watcher decides staleness; a failed read surfaces at once. */
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+    },
+  },
+});
+
 const router = createRouter({
+  context: { queryClient },
   defaultPreload: "intent",
+  // One cache owns staleness.
+  defaultPreloadStaleTime: 0,
   routeTree,
 });
 
@@ -23,5 +38,9 @@ export function App() {
     return <CaptureWindow />;
   }
 
-  return <RouterProvider router={router} />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
 }

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,3 +1,4 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
   DownloadIcon,
@@ -16,8 +17,8 @@ import {
   TagPlusIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useDebouncedCallback } from "use-debounce";
+import { useCallback, useRef, useState } from "react";
+import { useDebounce } from "use-debounce";
 import { useNoteTags } from "@/components/notes/use-note-tags";
 import {
   Command,
@@ -34,9 +35,9 @@ import type { NoteMeta } from "@/core/notes";
 import { filenameFromTitle } from "@/core/notes";
 import { createNote } from "@/data/create-note";
 import { deleteNote } from "@/data/delete-note";
-import { getNotes } from "@/data/get-notes";
 import { moveNote } from "@/data/move-note";
 import { setNotePinned } from "@/data/pin-note";
+import { noteQueries } from "@/data/queries";
 import { reindexAll } from "@/data/reindex";
 import { retitleNote } from "@/data/retitle-note";
 import { togglePref, usePref } from "@/lib/prefs";
@@ -354,6 +355,29 @@ function typewriterActionText(enabled: boolean) {
 
 type PaletteView = "delete" | "move" | "rename" | "root" | "tags";
 
+/**
+ * What the input asks the index for, or nothing when it asks for everything.
+ *
+ * A tag is an indexed exact match that ANDs with full-text search, so both
+ * paths run one query and differ only in what they pass.
+ */
+function searchFiltersFor(value: string, knownTags: Set<string>) {
+  const parsed = parseTagQuery(value);
+  const filters: { query: string; tag?: string } =
+    parsed === undefined
+      ? { query: value.trim() }
+      : { query: parsed.query, tag: parsed.tag };
+
+  if (
+    filters.query === "" &&
+    (filters.tag === undefined || !knownTags.has(filters.tag))
+  ) {
+    return;
+  }
+
+  return { limit: 30, ...filters };
+}
+
 interface CommandPaletteProps {
   allTags: { count: number; tag: string }[];
   folders: { count: number; folder: string }[];
@@ -363,6 +387,44 @@ interface CommandPaletteProps {
   onOpenSettings: () => void;
   open: boolean;
   tag?: string;
+}
+
+/** The rows under "notes": what the index answered, or the recent ones. */
+function useVisibleNotes(
+  query: string,
+  view: PaletteView,
+  knownTags: Set<string>,
+  notes: NoteMeta[]
+) {
+  const [debouncedQuery] = useDebounce(query, 150);
+  // The list only renders under the root view, and the other views repurpose
+  // the input, so nothing they hold should reach the index.
+  const filters =
+    view === "root" ? searchFiltersFor(debouncedQuery, knownTags) : undefined;
+  // The filters are the key, so a slow "a" resolving after "abc" lands in its
+  // own cache entry and never reaches the screen.
+  const { data: results, isError } = useQuery({
+    ...noteQueries.list(filters),
+    enabled: filters !== undefined,
+    placeholderData: keepPreviousData,
+  });
+  const tagQuery = parseTagQuery(query);
+
+  if (tagQuery !== undefined && !knownTags.has(tagQuery.tag)) {
+    return [];
+  }
+
+  // Asking for nothing builds the key the root loader already primed, and a
+  // disabled query still reads the cache, so its full list would land here.
+  if (filters === undefined) {
+    return notes.slice(0, 20);
+  }
+
+  if (isError) {
+    return [];
+  }
+
+  return results ?? notes.slice(0, 20);
 }
 
 export function CommandPalette({
@@ -396,69 +458,16 @@ export function CommandPalette({
   // and typing afterwards is never overwritten.
   const [query, setQuery] = useState(tag === undefined ? "" : `#${tag} `);
   const [view, setView] = useState<PaletteView>("root");
-  const [results, setResults] = useState<NoteMeta[] | null>(null);
-
-  // Only the newest search may write results: two in-flight queries can
-  // resolve out of order, and a slow "a" must not overwrite "abc". The counter
-  // advances when the input changes rather than when the debounced call fires,
-  // so a request already in flight is stale from the next keystroke on and not
-  // only from the moment its successor starts.
-  const latestSearchRef = useRef(0);
-
   const tagCounts = new Map(
     allTags.map(({ count, tag: name }) => [name, count])
   );
   const knownTags = new Set(tagCounts.keys());
-
-  // Tag filtering is an indexed exact match that ANDs with full-text search,
-  // so both paths run the same query and only differ in what they pass.
-  const search = useDebouncedCallback(
-    async (value: string, request: number) => {
-      const parsed = parseTagQuery(value);
-      const filters: { query: string; tag?: string } =
-        parsed === undefined
-          ? { query: value.trim() }
-          : { query: parsed.query, tag: parsed.tag };
-
-      if (
-        filters.query === "" &&
-        (filters.tag === undefined || !knownTags.has(filters.tag))
-      ) {
-        setResults(null);
-
-        return;
-      }
-
-      try {
-        const found = await getNotes({ limit: 30, ...filters });
-
-        if (latestSearchRef.current === request) {
-          setResults(found);
-        }
-      } catch {
-        if (latestSearchRef.current === request) {
-          setResults([]);
-        }
-      }
-    },
-    150
-  );
-
-  const updateQuery = useCallback(
-    (value: string) => {
-      latestSearchRef.current += 1;
-      setQuery(value);
-      search(value, latestSearchRef.current);
-    },
-    [search]
-  );
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
       if (!next) {
         setQuery("");
         setView("root");
-        setResults(null);
       }
 
       onOpenChange(next);
@@ -466,21 +475,8 @@ export function CommandPalette({
     [onOpenChange]
   );
 
-  useEffect(() => {
-    if (tag !== undefined) {
-      latestSearchRef.current += 1;
-      search(`#${tag} `, latestSearchRef.current);
-    }
-  }, [search, tag]);
-
   const tagQuery = parseTagQuery(query);
-  const visibleNotes = (() => {
-    if (tagQuery !== undefined && !knownTags.has(tagQuery.tag)) {
-      return [];
-    }
-
-    return results ?? notes.slice(0, 20);
-  })();
+  const visibleNotes = useVisibleNotes(query, view, knownTags, notes);
 
   const close = useCallback(() => {
     handleOpenChange(false);
@@ -599,12 +595,9 @@ export function CommandPalette({
     noteTags.changeTags([...noteTags.tags, draftTag]);
   }, [draftTag, noteTags]);
 
-  const filterByTag = useCallback(
-    (name: string) => {
-      updateQuery(`#${name} `);
-    },
-    [updateQuery]
-  );
+  const filterByTag = useCallback((name: string) => {
+    setQuery(`#${name} `);
+  }, []);
 
   const newNote = useCallback(() => {
     runAction(async () => {
@@ -794,7 +787,7 @@ export function CommandPalette({
         shouldFilter={false}
       >
         <CommandInput
-          onValueChange={updateQuery}
+          onValueChange={setQuery}
           placeholder={
             {
               delete: "search notes, # for tags...",

--- a/src/components/editor/code-block-view.tsx
+++ b/src/components/editor/code-block-view.tsx
@@ -2,7 +2,8 @@ import type { ReactNodeViewProps } from "@tiptap/react";
 
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 import { toast } from "@/components/ui/toast";
 
 import { lowlight } from "./extensions";
@@ -16,7 +17,9 @@ export function CodeBlockView({ node, updateAttributes }: ReactNodeViewProps) {
   const language =
     typeof node.attrs.language === "string" ? node.attrs.language : "";
   const [copied, setCopied] = useState(false);
-  const resetRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const clearCopied = useDebouncedCallback(() => {
+    setCopied(false);
+  }, 1500);
 
   // A fence can name a language lowlight does not know (```mermaid). Keep it
   // in the list, or the picker would silently rewrite it to "plain".
@@ -28,27 +31,17 @@ export function CodeBlockView({ node, updateAttributes }: ReactNodeViewProps) {
     ).toSorted();
   }, [language]);
 
-  useEffect(
-    () => () => {
-      clearTimeout(resetRef.current);
-    },
-    []
-  );
-
   const copy = useCallback(() => {
     navigator.clipboard
       .writeText(node.textContent)
       .then(() => {
         setCopied(true);
-        clearTimeout(resetRef.current);
-        resetRef.current = setTimeout(() => {
-          setCopied(false);
-        }, 1500);
+        clearCopied();
       })
       .catch(() => {
         toast.add({ title: "could not copy the code block", type: "error" });
       });
-  }, [node.textContent]);
+  }, [clearCopied, node.textContent]);
 
   const changeLanguage = useCallback(
     (event: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -103,12 +103,13 @@ export function Editor({
           const url = typeof attrs.href === "string" ? attrs.href : "";
           const coords = instance.view.coordsAtPos(head);
 
-          setLinkEditor({
+          setLinkEditor((previous) => ({
+            id: (previous?.id ?? 0) + 1,
             left: coords.left,
             needsText: empty && url === "",
             top: coords.bottom + 6,
             url,
-          });
+          }));
 
           return true;
         },
@@ -535,6 +536,7 @@ export function Editor({
       <EditorContent className="min-h-full" editor={editor} />
       {linkEditor === null || editor === null ? null : (
         <LinkEditor
+          key={linkEditor.id}
           onCancel={cancelLink}
           onRemove={removeLink}
           onSubmit={submitLink}

--- a/src/components/editor/link-editor.tsx
+++ b/src/components/editor/link-editor.tsx
@@ -2,6 +2,8 @@ import { CheckIcon, UnlinkIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface LinkEditorState {
+  /** Distinguishes one invocation from the next, so the popover remounts. */
+  id: number;
   /** Caret rect for positioning the popover. */
   left: number;
   /** Empty when creating a link with no selection (text field shown). */
@@ -29,23 +31,12 @@ export function LinkEditor({
   const containerRef = useRef<HTMLDivElement>(null);
   const firstFieldRef = useRef<HTMLInputElement>(null);
 
-  // The popover stays mounted between invocations, so a second ⌘⇧K on a
-  // different link arrives as a new `state` rather than a remount. Reset the
-  // draft during render (the pattern used in the notes route) and refocus
-  // afterwards.
-  const [syncedState, setSyncedState] = useState(state);
-
-  if (syncedState !== state) {
-    setSyncedState(state);
-    setUrl(state.url);
-    setText("");
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: state is the only signal a second invocation arrived; dropping it stops the refocus
+  // The caller keys this on `state.id`, so a second invocation arrives as a
+  // fresh mount and the draft starts empty without a reset pass.
   useEffect(() => {
     firstFieldRef.current?.focus();
     firstFieldRef.current?.select();
-  }, [state]);
+  }, []);
 
   // Clamp inside the viewport once rendered (same policy as the
   // suggestion menu).

--- a/src/components/notes/use-note-tags.spec.ts
+++ b/src/components/notes/use-note-tags.spec.ts
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { toast } from "@/components/ui/toast";
+import { setNoteTags } from "@/data/set-note-tags";
+
+import { useNoteTags } from "./use-note-tags";
+
+// The furthest boundary a hook test can reach: below this sit the Effect
+// runtime and a Tauri command, neither of which exists here.
+vi.mock("@/data/set-note-tags", () => ({ setNoteTags: vi.fn() }));
+
+// `act` refuses to run without this, and no setup file exists to set it.
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+type Live = ReturnType<typeof useNoteTags>;
+
+/** Drive the real hook in a real root, the way `use-autosave.spec.ts` does. */
+function mountNoteTags() {
+  const client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const root = createRoot(document.createElement("div"));
+  let live: Live | undefined;
+
+  function Probe({ path, tags }: { path: string; tags: string[] }) {
+    live = useNoteTags(path, tags);
+
+    return null;
+  }
+
+  return {
+    read: () => {
+      if (live === undefined) {
+        throw new Error("the probe never rendered");
+      }
+
+      return live;
+    },
+    show: (path: string, tags: string[]) => {
+      act(() => {
+        root.render(
+          createElement(
+            QueryClientProvider,
+            { client },
+            createElement(Probe, { path, tags })
+          )
+        );
+      });
+    },
+  };
+}
+
+/** A write that hangs until the test decides its fate. */
+function deferWrite() {
+  let fail: (error: Error) => void = () => undefined;
+
+  vi.mocked(setNoteTags).mockImplementationOnce(
+    () =>
+      new Promise((_resolve, reject) => {
+        fail = reject;
+      })
+  );
+
+  return (error: Error) => {
+    fail(error);
+  };
+}
+
+/**
+ * `mutate` awaits `onMutate` before it reaches the write, and the rejection
+ * then walks Query's callback chain, so both need a turn of the loop.
+ */
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+}
+
+describe("useNoteTags", () => {
+  beforeEach(() => {
+    vi.mocked(setNoteTags).mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("should keep the showing note's pending tags when an earlier note's write fails", async () => {
+    const failFirst = deferWrite();
+
+    deferWrite();
+    const reported = vi.spyOn(toast, "add").mockReturnValue("");
+
+    const { read, show } = mountNoteTags();
+
+    show("a.md", []);
+    act(() => {
+      read().changeTags(["one"]);
+    });
+    await flush();
+
+    show("b.md", ["two"]);
+    act(() => {
+      read().changeTags(["two", "three"]);
+    });
+    await flush();
+
+    failFirst(new Error("disk said no"));
+    await flush();
+
+    expect(read().tags).toEqual(["two", "three"]);
+    expect(reported).not.toHaveBeenCalled();
+  });
+
+  it("should roll the showing note back to its saved tags when its own write fails", async () => {
+    const failOnly = deferWrite();
+    const reported = vi.spyOn(toast, "add").mockReturnValue("");
+
+    const { read, show } = mountNoteTags();
+
+    show("a.md", ["kept"]);
+    act(() => {
+      read().changeTags(["kept", "added"]);
+    });
+    await flush();
+
+    expect(read().tags).toEqual(["kept", "added"]);
+    expect(vi.mocked(setNoteTags)).toHaveBeenCalledTimes(1);
+
+    failOnly(new Error("disk said no"));
+    await flush();
+
+    expect(read().tags).toEqual(["kept"]);
+    expect(reported).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/notes/use-note-tags.ts
+++ b/src/components/notes/use-note-tags.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { toast } from "@/components/ui/toast";
 import { setNoteTags } from "@/data/set-note-tags";
@@ -27,6 +27,15 @@ export function useNoteTags(path: string, tags: string[]) {
     setOptimisticTags(tags);
   }
 
+  // A path change resets the observer, and a mutation already in flight keeps
+  // the options it held then. Restoring from the callback's own `tags` would
+  // put the previous note's set onto the one now showing.
+  const savedTags = useRef(tags);
+
+  useEffect(() => {
+    savedTags.current = tags;
+  });
+
   const { mutate: changeTags } = useMutation({
     mutationFn: (nextTags: string[]) => setNoteTags(path, nextTags),
     mutationKey,
@@ -38,7 +47,7 @@ export function useNoteTags(path: string, tags: string[]) {
         return;
       }
 
-      setOptimisticTags(tags);
+      setOptimisticTags(savedTags.current);
       toast.add({ title: "could not update tags", type: "error" });
     },
     onMutate: (nextTags: string[]) => {

--- a/src/components/notes/use-note-tags.ts
+++ b/src/components/notes/use-note-tags.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { toast } from "@/components/ui/toast";
 import { setNoteTags } from "@/data/set-note-tags";
@@ -28,18 +28,25 @@ export function useNoteTags(path: string, tags: string[]) {
   }
 
   // A path change resets the observer, and a mutation already in flight keeps
-  // the options it held then. Restoring from the callback's own `tags` would
-  // put the previous note's set onto the one now showing.
-  const savedTags = useRef(tags);
+  // the options it held then, so its callbacks speak for the note it started
+  // on. Layout, not passive: a rejection lands in a microtask and can beat a
+  // passive effect to this.
+  const active = useRef({ path, tags });
 
-  useEffect(() => {
-    savedTags.current = tags;
+  useLayoutEffect(() => {
+    active.current = { path, tags };
   });
 
   const { mutate: changeTags } = useMutation({
     mutationFn: (nextTags: string[]) => setNoteTags(path, nextTags),
     mutationKey,
     onError: () => {
+      // A note the user has left owns neither the row nor the toast, and its
+      // rollback would land on whatever the showing note has pending.
+      if (path !== active.current.path) {
+        return;
+      }
+
       // This one still counts as pending here, so anything above one is a
       // later toggle queued behind it, which will decide the display itself.
       // An older failure must not restore a set the user moved past (`D31`).
@@ -47,7 +54,7 @@ export function useNoteTags(path: string, tags: string[]) {
         return;
       }
 
-      setOptimisticTags(savedTags.current);
+      setOptimisticTags(active.current.tags);
       toast.add({ title: "could not update tags", type: "error" });
     },
     onMutate: (nextTags: string[]) => {

--- a/src/components/notes/use-note-tags.ts
+++ b/src/components/notes/use-note-tags.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
-import { toast } from "@/components/ui/toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 
+import { toast } from "@/components/ui/toast";
 import { setNoteTags } from "@/data/set-note-tags";
 
 /**
@@ -10,12 +11,14 @@ import { setNoteTags } from "@/data/set-note-tags";
  * fixed once rather than per surface (`D31`).
  */
 export function useNoteTags(path: string, tags: string[]) {
+  const queryClient = useQueryClient();
+  const mutationKey = ["note-tags", path];
   const [optimisticTags, setOptimisticTags] = useState(tags);
 
-  // Optimistic state follows the loader (adjust-during-render pattern): an
-  // agent editing the frontmatter on disk must show up here instead of being
-  // stuck on whatever we last set ourselves. Compared by value -- the loader
-  // hands back a fresh array every refresh.
+  // Optimistic state follows the file (adjust-during-render pattern): an agent
+  // editing the frontmatter on disk has to show up here rather than leaving
+  // the row stuck on whatever we last set. Compared by value, since every
+  // re-read hands back a fresh array.
   const tagsKey = tags.join("\n");
   const [syncedTags, setSyncedTags] = useState(tagsKey);
 
@@ -24,43 +27,28 @@ export function useNoteTags(path: string, tags: string[]) {
     setOptimisticTags(tags);
   }
 
-  // The loader's tags are the last set known to be on disk, so they are what a
-  // failed write falls back to. Held in a ref because the write resolves long
-  // after the render that started it.
-  const savedRef = useRef(tags);
-
-  useEffect(() => {
-    savedRef.current = tags;
-  });
-
-  const queueRef = useRef(Promise.resolve());
-  const latestRef = useRef(0);
-
-  // Writing tags is a read-modify-write of the file (`NoteService.setTags`), so
-  // two in flight can land in either order and leave disk holding the older
-  // set. Chaining them makes the last call the last write.
-  const changeTags = (nextTags: string[]) => {
-    const request = latestRef.current + 1;
-
-    latestRef.current = request;
-    setOptimisticTags(nextTags);
-
-    queueRef.current = queueRef.current.then(async () => {
-      try {
-        await setNoteTags(path, nextTags);
-      } catch {
-        // Only the newest change owns what is displayed. An older failure must
-        // not restore a set the user has already moved past, and must not
-        // report a failure they have already superseded.
-        if (latestRef.current === request) {
-          setOptimisticTags(savedRef.current);
-          toast.add({ title: "could not update tags", type: "error" });
-        }
+  const { mutate: changeTags } = useMutation({
+    mutationFn: (nextTags: string[]) => setNoteTags(path, nextTags),
+    mutationKey,
+    onError: () => {
+      // This one still counts as pending here, so anything above one is a
+      // later toggle queued behind it, which will decide the display itself.
+      // An older failure must not restore a set the user moved past (`D31`).
+      if (queryClient.isMutating({ mutationKey }) > 1) {
+        return;
       }
-    });
 
-    return queueRef.current;
-  };
+      setOptimisticTags(tags);
+      toast.add({ title: "could not update tags", type: "error" });
+    },
+    onMutate: (nextTags: string[]) => {
+      setOptimisticTags(nextTags);
+    },
+    // `NoteService.setTags` is a read-modify-write of the file, so two in
+    // flight could land in either order. The scope is the note rather than the
+    // hook, so the two surfaces `D31` allows serialize against each other too.
+    scope: { id: path },
+  });
 
   return { changeTags, tags: optimisticTags };
 }

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,4 +1,9 @@
-import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect } from "react";
@@ -77,19 +82,27 @@ export function SettingsDialog({
     }
   }, [queryClient]);
 
-  const toggleAutostart = useCallback(
-    async (value: boolean) => {
-      queryClient.setQueryData(autostartQuery.queryKey, value);
-
-      try {
-        await (value ? enable() : disable());
-      } catch {
-        // The OS holds the truth, so a failure reverts by re-reading it.
-        queryClient.invalidateQueries({ queryKey: autostartQuery.queryKey });
-        toast.add({ title: "could not update launch at login", type: "error" });
-      }
+  const { isPending: autostartPending, mutate: writeAutostart } = useMutation({
+    mutationFn: (value: boolean) => (value ? enable() : disable()),
+    onError: () => {
+      // The OS holds the truth, so a failure reverts by re-reading it.
+      queryClient.invalidateQueries({ queryKey: autostartQuery.queryKey });
+      toast.add({ title: "could not update launch at login", type: "error" });
     },
-    [queryClient]
+    onMutate: (value: boolean) => {
+      queryClient.setQueryData(autostartQuery.queryKey, value);
+    },
+    // Two quick toggles must not reach the OS out of order.
+    scope: { id: "autostart" },
+  });
+
+  // Base UI hands the change handler a second argument, where `mutate` expects
+  // its own options.
+  const toggleAutostart = useCallback(
+    (value: boolean) => {
+      writeAutostart(value);
+    },
+    [writeAutostart]
   );
 
   return (
@@ -118,7 +131,11 @@ export function SettingsDialog({
             <Label htmlFor="autostart">launch at login</Label>
             <Switch
               checked={autostart ?? false}
-              disabled={autostartUnreadable || autostart === undefined}
+              disabled={
+                autostartPending ||
+                autostartUnreadable ||
+                autostart === undefined
+              }
               id="autostart"
               onCheckedChange={toggleAutostart}
             />

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,7 +1,7 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -23,32 +23,36 @@ interface SettingsDialogProps {
   open: boolean;
 }
 
+/**
+ * Launch at login, owned by the OS rather than the index, so it is keyed here
+ * rather than in `src/data/queries.ts` alongside the reads that go through the
+ * Effect runtime.
+ */
+const autostartQuery = queryOptions({
+  queryFn: isEnabled,
+  queryKey: ["autostart"] as const,
+});
+
 export function SettingsDialog({
   notesDir,
   onOpenChange,
   open,
 }: SettingsDialogProps) {
   const queryClient = useQueryClient();
-  const [autostart, setAutostart] = useState(false);
-  // The switch cannot claim "off" when the real state is unknown.
-  const [autostartReadable, setAutostartReadable] = useState(true);
+  // Read when the dialog opens, never on launch: nothing else shows it.
+  const { data: autostart, isError: autostartUnreadable } = useQuery({
+    ...autostartQuery,
+    enabled: open,
+  });
 
   useEffect(() => {
-    if (open) {
-      isEnabled()
-        .then((enabled) => {
-          setAutostart(enabled);
-          setAutostartReadable(true);
-        })
-        .catch(() => {
-          setAutostartReadable(false);
-          toast.add({
-            title: "could not read the launch at login setting",
-            type: "error",
-          });
-        });
+    if (autostartUnreadable) {
+      toast.add({
+        title: "could not read the launch at login setting",
+        type: "error",
+      });
     }
-  }, [open]);
+  }, [autostartUnreadable]);
 
   const changeNotesDir = useCallback(async () => {
     try {
@@ -73,16 +77,20 @@ export function SettingsDialog({
     }
   }, [queryClient]);
 
-  const toggleAutostart = useCallback(async (value: boolean) => {
-    setAutostart(value);
+  const toggleAutostart = useCallback(
+    async (value: boolean) => {
+      queryClient.setQueryData(autostartQuery.queryKey, value);
 
-    try {
-      await (value ? enable() : disable());
-    } catch {
-      setAutostart(!value);
-      toast.add({ title: "could not update launch at login", type: "error" });
-    }
-  }, []);
+      try {
+        await (value ? enable() : disable());
+      } catch {
+        // The OS holds the truth, so a failure reverts by re-reading it.
+        queryClient.invalidateQueries({ queryKey: autostartQuery.queryKey });
+        toast.add({ title: "could not update launch at login", type: "error" });
+      }
+    },
+    [queryClient]
+  );
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -109,8 +117,8 @@ export function SettingsDialog({
           <div className="flex items-center justify-between">
             <Label htmlFor="autostart">launch at login</Label>
             <Switch
-              checked={autostart}
-              disabled={!autostartReadable}
+              checked={autostart ?? false}
+              disabled={autostartUnreadable}
               id="autostart"
               onCheckedChange={toggleAutostart}
             />

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useState } from "react";
@@ -28,7 +28,7 @@ export function SettingsDialog({
   onOpenChange,
   open,
 }: SettingsDialogProps) {
-  const router = useRouter();
+  const queryClient = useQueryClient();
   const [autostart, setAutostart] = useState(false);
   // The switch cannot claim "off" when the real state is unknown.
   const [autostartReadable, setAutostartReadable] = useState(true);
@@ -62,7 +62,8 @@ export function SettingsDialog({
       }
 
       await setNotesDir(selected);
-      await router.invalidate();
+      // A different folder invalidates every read the old one answered.
+      await queryClient.invalidateQueries();
       toast.add({ title: "notes folder updated", type: "success" });
     } catch (error) {
       toast.add({
@@ -70,7 +71,7 @@ export function SettingsDialog({
         type: "error",
       });
     }
-  }, [router]);
+  }, [queryClient]);
 
   const toggleAutostart = useCallback(async (value: boolean) => {
     setAutostart(value);

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -118,7 +118,7 @@ export function SettingsDialog({
             <Label htmlFor="autostart">launch at login</Label>
             <Switch
               checked={autostart ?? false}
-              disabled={autostartUnreadable}
+              disabled={autostartUnreadable || autostart === undefined}
               id="autostart"
               onCheckedChange={toggleAutostart}
             />

--- a/src/components/tabs/tab-strip.tsx
+++ b/src/components/tabs/tab-strip.tsx
@@ -18,7 +18,7 @@ import {
   SortableContext,
   useSortable,
 } from "@dnd-kit/sortable";
-import { getRouteApi } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -41,6 +41,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { noteTitle } from "@/core/notes";
+import { noteQueries } from "@/data/queries";
 import {
   activateTab,
   closeOtherTabs,
@@ -53,8 +54,6 @@ import type { Tab, TabStep } from "@/lib/tabs/tab";
 import { stepTab, tabButtonId, tabId, tabPanelId } from "@/lib/tabs/tab";
 import { CHROME_GLYPH } from "@/lib/ui/chrome";
 import { cn } from "@/lib/ui/utils";
-
-const rootApi = getRouteApi("__root__");
 
 const STEPS: Record<string, TabStep> = {
   ArrowLeft: "previous",
@@ -337,7 +336,7 @@ interface TabListProps {
  * go, so it hands the press to the window instead.
  */
 function TabList({ activeId, tabs }: TabListProps) {
-  const { notes } = rootApi.useLoaderData();
+  const { data: notes } = useSuspenseQuery(noteQueries.list());
   const listRef = useRef<HTMLDivElement>(null);
   const [hidden, setHidden] = useState<string[]>([]);
   const ids = useMemo(() => tabs.map(tabId), [tabs]);

--- a/src/components/workspace/note-session.tsx
+++ b/src/components/workspace/note-session.tsx
@@ -1,4 +1,4 @@
-import { getRouteApi } from "@tanstack/react-router";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { EditorHandle } from "@/components/editor/editor";
@@ -11,8 +11,9 @@ import { toast } from "@/components/ui/toast";
 import { FileError } from "@/core/errors";
 import { composeNote, parseNote } from "@/core/frontmatter";
 import { noteFolder, noteTitle, resolveTitle } from "@/core/notes";
-import { readExternalNote, writeExternalNote } from "@/data/external-note";
-import { getNote } from "@/data/get-note";
+import { writeExternalNote } from "@/data/external-note";
+import type { SessionFile } from "@/data/queries";
+import { noteQueries, notesDirQuery } from "@/data/queries";
 import { saveNote } from "@/data/save-note";
 import { usePref } from "@/lib/prefs";
 import {
@@ -20,8 +21,8 @@ import {
   closeTab,
   openNote,
   publishTabSnapshot,
+  registerTabHandles,
   restoredCaret,
-  subscribeRevision,
 } from "@/lib/tabs/store";
 import type { Tab } from "@/lib/tabs/tab";
 import { tabButtonId, tabId, tabPanelId } from "@/lib/tabs/tab";
@@ -29,38 +30,6 @@ import { errorMessage } from "@/lib/ui/failure";
 import { cn } from "@/lib/ui/utils";
 import { decodeAttachmentPath } from "@/lib/utils/attachments";
 import { countWords } from "@/lib/utils/word-count";
-
-const rootApi = getRouteApi("__root__");
-
-/** One tab's file as of the last read. An external file reports no pin and no tags (`D54`). */
-interface SessionFile {
-  content: string;
-  pinned: boolean;
-  tags: string[];
-  updatedAt: Date;
-}
-
-async function readTab(kind: Tab["kind"], path: string): Promise<SessionFile> {
-  if (kind === "external") {
-    const file = await readExternalNote(path);
-
-    return {
-      content: file.content,
-      pinned: false,
-      tags: [],
-      updatedAt: file.updatedAt,
-    };
-  }
-
-  const note = await getNote(path);
-
-  return {
-    content: note.content,
-    pinned: note.pinned,
-    tags: note.tags,
-    updatedAt: note.updatedAt,
-  };
-}
 
 interface SessionBufferProps {
   active: boolean;
@@ -77,7 +46,8 @@ interface SessionBufferProps {
  * a hotkey: those belong to the workspace, and `D53` says why.
  */
 function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
-  const { notes, notesDir } = rootApi.useLoaderData();
+  const { data: notes } = useSuspenseQuery(noteQueries.list());
+  const { data: notesDir } = useSuspenseQuery(notesDirQuery);
   const id = tabId(tab);
 
   const editorRef = useRef<EditorHandle | null>(null);
@@ -88,12 +58,6 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   const [frontmatterBlock, setFrontmatterLines] = useState(
     () => parseNote(file.content).raw
   );
-  const frontmatterRef = useRef(frontmatterBlock);
-
-  useEffect(() => {
-    frontmatterRef.current = frontmatterBlock;
-  });
-
   // Frontmatter follows the file (adjust-during-render pattern): a pin or tag
   // toggle rewrites it, and the next body save must compose with that fresh
   // block, not the one captured at mount.
@@ -111,21 +75,9 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   }
 
   const [body, setBody] = useState(() => parseNote(file.content).body);
-  const bodyRef = useRef(body);
-
-  useEffect(() => {
-    bodyRef.current = body;
-  });
-
   const [words, setWords] = useState(() => countWords(file.content));
   const [reloadKey, setReloadKey] = useState(0);
   const [sourceMode, setSourceMode] = useState(false);
-  const sourceModeRef = useRef(sourceMode);
-
-  useEffect(() => {
-    sourceModeRef.current = sourceMode;
-  });
-
   // Anchors carried across mode toggles so the caret keeps its spot.
   const [sourceCursor, setSourceCursor] = useState(0);
   // Body carrying a sentinel char at the caret (set when leaving source mode,
@@ -164,14 +116,27 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   // Stable across renders, unlike `autosave` itself (a fresh object every
   // render, since `status` changes on every keystroke).
   const { onChange } = autosave;
-  // Read by the effect below, which decides once and must not re-decide when a
-  // write that was already in flight resolves.
-  const statusRef = useRef(autosave.status);
 
-  useEffect(() => {
-    statusRef.current = autosave.status;
+  // The editor freezes its props at mount, so its callbacks read live values
+  // through this rather than through closures over render state. Declared
+  // ahead of every effect that reads it, since effects run in order.
+  const live = useRef({
+    body,
+    frontmatter: frontmatterBlock,
+    notes,
+    sourceMode,
+    status: autosave.status,
   });
 
+  useEffect(() => {
+    live.current = {
+      body,
+      frontmatter: frontmatterBlock,
+      notes,
+      sourceMode,
+      status: autosave.status,
+    };
+  });
   // `D32`'s chain, resolved off the live buffer rather than the last read, so
   // the tab label follows a heading as it is typed. An external file has no
   // frontmatter contract, so it is named by its file.
@@ -186,14 +151,8 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
 
   // Live values behind stable getters, so the mount-frozen editor callbacks
   // never go stale.
-  const notesRef = useRef(notes);
-
-  useEffect(() => {
-    notesRef.current = notes;
-  });
-
   const getTitles = useCallback(
-    () => notesRef.current.map((meta) => meta.title),
+    () => live.current.notes.map((meta) => meta.title),
     []
   );
 
@@ -212,7 +171,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
     (linkTitle: string) => {
       const wanted = linkTitle.trim().toLowerCase();
       const currentFolder = noteFolder(tab.path);
-      const target = notesRef.current
+      const target = live.current.notes
         .filter(
           (meta) =>
             meta.title.toLowerCase() === wanted ||
@@ -261,7 +220,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
 
   const handleBodyChange = useCallback(
     (nextBody: string) => {
-      const full = composeNote(frontmatterRef.current, nextBody);
+      const full = composeNote(live.current.frontmatter, nextBody);
 
       setBody(nextBody);
       setWords(countWords(full));
@@ -295,7 +254,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   // Body-relative, so source mode has to shed the frontmatter prefix the way
   // `toggleSource` does.
   const getCaret = useCallback(() => {
-    if (!sourceModeRef.current) {
+    if (!live.current.sourceMode) {
       return editorRef.current?.getCaretSourceOffset() ?? -1;
     }
 
@@ -305,19 +264,19 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
       return -1;
     }
 
-    const raw = composeNote(frontmatterRef.current, bodyRef.current);
+    const raw = composeNote(live.current.frontmatter, live.current.body);
 
     return Math.max(
       0,
       Math.min(
-        offset - (raw.length - bodyRef.current.length),
-        bodyRef.current.length
+        offset - (raw.length - live.current.body.length),
+        live.current.body.length
       )
     );
   }, []);
 
   const insertText = useCallback((text: string) => {
-    const target = sourceModeRef.current
+    const target = live.current.sourceMode
       ? sourceRef.current
       : editorRef.current;
 
@@ -335,18 +294,18 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   // comes off a ref, since the snapshot the chrome calls this through has to
   // stay stable.
   const toggleSource = useCallback(() => {
-    const raw = composeNote(frontmatterRef.current, bodyRef.current);
-    const prefixLength = raw.length - bodyRef.current.length;
-    const wasSource = sourceModeRef.current;
+    const raw = composeNote(live.current.frontmatter, live.current.body);
+    const prefixLength = raw.length - live.current.body.length;
+    const wasSource = live.current.sourceMode;
 
     if (wasSource) {
       const offset = sourceRef.current?.getCursorOffset() ?? 0;
       const bodyOffset = Math.max(
         0,
-        Math.min(offset - prefixLength, bodyRef.current.length)
+        Math.min(offset - prefixLength, live.current.body.length)
       );
 
-      setSentineledBody(insertSentinel(bodyRef.current, bodyOffset));
+      setSentineledBody(insertSentinel(live.current.body, bodyOffset));
       setReloadKey((key) => key + 1);
     } else {
       const offset = editorRef.current?.getCaretSourceOffset() ?? -1;
@@ -357,21 +316,22 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
     setSourceMode(!wasSource);
   }, []);
 
+  useEffect(() => {
+    registerTabHandles(id, { getCaret, insertText, toggleSource });
+  }, [getCaret, id, insertText, toggleSource]);
+
   // The chrome renders once above every session, so what it draws travels up
   // through the store rather than down through props.
   useEffect(() => {
     publishTabSnapshot(id, {
-      getCaret,
-      insertText,
       pinned: file.pinned,
       sourceMode,
       status: autosave.status,
       tags: file.tags,
       title,
-      toggleSource,
       words,
     });
-  });
+  }, [autosave.status, file.pinned, file.tags, id, sourceMode, title, words]);
 
   // A file that has gone takes its tab with it when the buffer holds nothing
   // worth keeping. Writing stops through `enabled` above, so the text can be
@@ -382,7 +342,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
   // resolved and reported `saved`, throwing away the buffer this exists to
   // keep.
   useEffect(() => {
-    if (missing && statusRef.current === "saved") {
+    if (missing && live.current.status === "saved") {
       closeTab(id);
     }
   }, [missing, id]);
@@ -395,7 +355,7 @@ function SessionBuffer({ active, file, missing, tab }: SessionBufferProps) {
       return;
     }
 
-    if (sourceModeRef.current) {
+    if (live.current.sourceMode) {
       sourceRef.current?.focus();
     } else {
       editorRef.current?.focus();
@@ -459,62 +419,28 @@ interface NoteSessionProps {
  */
 export function NoteSession({ active, tab }: NoteSessionProps) {
   const { kind, path } = tab;
-  const [file, setFile] = useState<null | SessionFile>(null);
-  const [gone, setGone] = useState(false);
-  // A watcher bump re-reads every tab, so a file that keeps refusing would
-  // toast once per revision. Holding the message rather than a flag lets
-  // React's bail-out collapse a repeat into one toast, which is the stacking
-  // `D38` rejected.
-  const [unreadable, setUnreadable] = useState<null | string>(null);
+  const { data, error } = useQuery(noteQueries.file(kind, path));
+  // A rename changes the key (`D56`) and a failed read clears the data, and
+  // neither may take the buffer with it: the tab keeps what it last read
+  // (`D55`). Query's own `keepPreviousData` covers only the pending case.
+  const lastRead = useRef<SessionFile | undefined>(undefined);
 
   useEffect(() => {
-    let cancelled = false;
-    // A burst of watcher events starts several reads, and nothing makes them
-    // resolve in order. Only the newest may write state: an older rejection
-    // landing after a newer success would put the gone banner back up over a
-    // file that is there.
-    let latest = 0;
+    if (data !== undefined) {
+      lastRead.current = data;
+    }
+  }, [data]);
 
-    const read = () => {
-      latest += 1;
-      const attempt = latest;
-      const stale = () => cancelled || attempt !== latest;
+  const file = data ?? lastRead.current;
 
-      readTab(kind, path)
-        .then((next) => {
-          if (!stale()) {
-            setFile(next);
-            setGone(false);
-            setUnreadable(null);
-          }
-        })
-        .catch((error: unknown) => {
-          if (stale()) {
-            return;
-          }
-
-          // Only a missing file is a deletion. A permission or IO failure
-          // leaves the note where it was, so the tab keeps what it last read
-          // (`D55`).
-          if (error instanceof FileError && error.kind === "not-found") {
-            setGone(true);
-
-            return;
-          }
-
-          setUnreadable(errorMessage(error, "could not read this note"));
-        });
-    };
-
-    read();
-
-    const unsubscribe = subscribeRevision(read);
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-    };
-  }, [kind, path]);
+  // Only a missing file is a deletion. A permission or IO failure leaves the
+  // note where it was, so the tab keeps what it last read (`D55`).
+  const gone = error instanceof FileError && error.kind === "not-found";
+  // A repeat leaves the message unchanged, so the effect skips (`D38`).
+  const unreadable =
+    error === null || gone
+      ? null
+      : errorMessage(error, "could not read this note");
 
   useEffect(() => {
     if (unreadable !== null) {
@@ -526,12 +452,12 @@ export function NoteSession({ active, tab }: NoteSessionProps) {
   // show. A failed re-read of a tab that does have one is the buffer's own
   // decision, made in `SessionBuffer`.
   useEffect(() => {
-    if (gone && file === null) {
+    if (gone && file === undefined) {
       closeTab(tab.id);
     }
   }, [gone, file, tab.id]);
 
-  if (file === null) {
+  if (file === undefined) {
     return null;
   }
 

--- a/src/data/queries.ts
+++ b/src/data/queries.ts
@@ -1,0 +1,85 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import type { NoteFilters } from "@/core/notes";
+import type { Tab } from "@/lib/tabs/tab";
+
+import { readExternalNote } from "./external-note";
+import { getFolders } from "./get-folders";
+import { getNote } from "./get-note";
+import { getNotes } from "./get-notes";
+import { getTags } from "./get-tags";
+import { getNotesDir } from "./notes-dir";
+
+// Not members: reading the object while it is still being built widens it
+// to `any`.
+const all = ["notes"] as const;
+const index = [...all, "index"] as const;
+const fileKey = (kind: Tab["kind"], path: string) =>
+  [...all, "file", kind, path] as const;
+
+/** One tab's file as of the last read. An external file reports no pin and no tags (`D54`). */
+export interface SessionFile {
+  content: string;
+  pinned: boolean;
+  tags: string[];
+  updatedAt: Date;
+}
+
+async function readTab(kind: Tab["kind"], path: string): Promise<SessionFile> {
+  if (kind === "external") {
+    const file = await readExternalNote(path);
+
+    return {
+      content: file.content,
+      pinned: false,
+      tags: [],
+      updatedAt: file.updatedAt,
+    };
+  }
+
+  const note = await getNote(path);
+
+  return {
+    content: note.content,
+    pinned: note.pinned,
+    tags: note.tags,
+    updatedAt: note.updatedAt,
+  };
+}
+
+/** Keyed generic to specific: every invalidation is one prefix. */
+export const noteQueries = {
+  all,
+  file: (kind: Tab["kind"], path: string) =>
+    queryOptions({
+      queryFn: () => readTab(kind, path),
+      queryKey: fileKey(kind, path),
+      // No payload names a path outside the notes dir, so focus is the signal.
+      // "always" and not `true`: staleTime is infinite, so a stale check the
+      // query can never fail would refetch on nothing.
+      refetchOnWindowFocus: kind === "external" ? "always" : false,
+    }),
+  fileKey,
+  folders: () =>
+    queryOptions({
+      queryFn: getFolders,
+      queryKey: [...index, "folders"] as const,
+    }),
+  index,
+  list: (filters?: NoteFilters) =>
+    queryOptions({
+      queryFn: () => getNotes(filters),
+      queryKey: [...index, "list", filters ?? null] as const,
+    }),
+  tags: () =>
+    queryOptions({
+      queryFn: getTags,
+      queryKey: [...index, "tags"] as const,
+    }),
+};
+
+/** Settings rather than index: no write to a note can move it. */
+export const notesDirQuery = queryOptions({
+  queryFn: getNotesDir,
+  queryKey: ["notes-dir"] as const,
+});

--- a/src/lib/tabs/store.spec.ts
+++ b/src/lib/tabs/store.spec.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { getTabState, restoredCaret, restoreTabs } from "./store";
+import {
+  closeTab,
+  getTabHandles,
+  getTabState,
+  openNote,
+  registerTabHandles,
+  restoredCaret,
+  restoreTabs,
+} from "./store";
 import { serializeTabs } from "./tab";
 
 const STORAGE_KEY = "tabs";
@@ -81,5 +89,40 @@ describe("restoreTabs", () => {
     expect(getTabState().activeId).toBe(b?.id);
     expect(restoredCaret(a?.id ?? "")).toBe(12);
     expect(restoredCaret(b?.id ?? "")).toBe(34);
+  });
+});
+
+describe("registerTabHandles", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("should hand back the handles a live tab registered", () => {
+    openNote("a.md");
+    const [tab] = getTabState().tabs;
+    const handles = {
+      getCaret: () => 7,
+      insertText: () => undefined,
+      toggleSource: () => undefined,
+    };
+
+    registerTabHandles(tab?.id ?? "", handles);
+
+    expect(getTabHandles(tab?.id ?? "")?.getCaret()).toBe(7);
+  });
+
+  it("should forget a tab's handles once it closes", () => {
+    openNote("b.md");
+    const [tab] = getTabState().tabs;
+    const id = tab?.id ?? "";
+
+    registerTabHandles(id, {
+      getCaret: () => 7,
+      insertText: () => undefined,
+      toggleSource: () => undefined,
+    });
+    closeTab(id);
+
+    expect(getTabHandles(id)).toBeUndefined();
   });
 });

--- a/src/lib/tabs/store.ts
+++ b/src/lib/tabs/store.ts
@@ -20,22 +20,25 @@ import {
 const STORAGE_KEY = "tabs";
 
 /**
- * What a session publishes for the chrome to draw (`D53`).
- *
- * `toggleSource` rides along because switching surfaces carries the caret
- * through the editor handle, which only the session holds.
+ * What a session lends the chrome to act on it, read by id at the moment of
+ * use. Never rendered, so registering one notifies nobody.
  */
-export interface TabSnapshot {
+export interface TabHandles {
   /** The caret's offset in this buffer's markdown, or -1. Read only when the set is persisted. */
   getCaret: () => number;
   /** Into whichever surface is live, since ⌘P swaps which one owns the caret. */
   insertText: (text: string) => void;
+  /** Switching surfaces carries the caret through the editor handle, which only the session holds. */
+  toggleSource: () => void;
+}
+
+/** What a session publishes for the chrome to draw (`D53`). */
+export interface TabSnapshot {
   pinned: boolean;
   sourceMode: boolean;
   status: SaveStatus;
   tags: string[];
   title: string;
-  toggleSource: () => void;
   words: number;
 }
 
@@ -44,9 +47,9 @@ let closed: ClosedTab[] = [];
 /** Carets read back at launch, each consumed once by the session that mounts. */
 const restored = new Map<string, number>();
 
+const handles = new Map<string, TabHandles>();
 const snapshots = new Map<string, TabSnapshot>();
 const listeners = new Set<() => void>();
-const readers = new Set<() => void>();
 
 function emit() {
   for (const listener of listeners) {
@@ -67,10 +70,16 @@ function setState(next: TabState) {
     return;
   }
 
-  // A tab that left takes its snapshot with it. Doing this here rather than at
-  // each call site is what covers `openTab` replacing the active tab, where a
-  // surviving snapshot would let the chrome read a destroyed session.
+  // A tab that left takes both with it. Doing this here rather than at each
+  // call site is what covers `openTab` replacing the active tab, where a
+  // survivor would let the chrome read a destroyed session.
   const open = new Set(next.tabs.map(tabId));
+
+  for (const id of handles.keys()) {
+    if (!open.has(id)) {
+      handles.delete(id);
+    }
+  }
 
   for (const id of snapshots.keys()) {
     if (!open.has(id)) {
@@ -95,7 +104,7 @@ export function persistTabs() {
 
   for (const tab of state.tabs) {
     const id = tabId(tab);
-    const caret = snapshots.get(id)?.getCaret() ?? -1;
+    const caret = handles.get(id)?.getCaret() ?? -1;
 
     if (caret >= 0) {
       carets[id] = caret;
@@ -174,7 +183,7 @@ export function useTabState() {
   return useSyncExternalStore(subscribe, getTabState);
 }
 
-export function getTabSnapshot(id: string) {
+function getTabSnapshot(id: string) {
   return snapshots.get(id);
 }
 
@@ -185,44 +194,17 @@ export function useTabSnapshot(id: string) {
   );
 }
 
-/**
- * Re-read this session's file whenever the folder changes. The watcher fires
- * one `notes-changed` for the whole folder, and every live session reconciles
- * off that one signal.
- */
-export function subscribeRevision(reader: () => void) {
-  readers.add(reader);
-
-  return () => {
-    readers.delete(reader);
-  };
+export function getTabHandles(id: string) {
+  return handles.get(id);
 }
 
-export function bumpRevision() {
-  for (const reader of readers) {
-    reader();
-  }
+/** Called once per session. Nothing subscribes, so this does not emit. */
+export function registerTabHandles(id: string, next: TabHandles) {
+  handles.set(id, next);
 }
 
 /** Called by a session on every change it makes to what the chrome shows. */
 export function publishTabSnapshot(id: string, snapshot: TabSnapshot) {
-  const current = snapshots.get(id);
-
-  if (
-    current !== undefined &&
-    current.getCaret === snapshot.getCaret &&
-    current.insertText === snapshot.insertText &&
-    current.pinned === snapshot.pinned &&
-    current.sourceMode === snapshot.sourceMode &&
-    current.status === snapshot.status &&
-    current.tags === snapshot.tags &&
-    current.title === snapshot.title &&
-    current.toggleSource === snapshot.toggleSource &&
-    current.words === snapshot.words
-  ) {
-    return;
-  }
-
   snapshots.set(id, snapshot);
   emit();
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -52,6 +52,17 @@ export const Route = createRootRouteWithContext<{
   },
 });
 
+/** `listen` resolves to its own unsubscribe, which every effect here drops. */
+function disposeLater(...pending: Promise<() => void>[]) {
+  return () => {
+    for (const unlisten of pending) {
+      unlisten.then((dispose) => {
+        dispose();
+      });
+    }
+  };
+}
+
 const HOTKEY_OPTIONS = {
   enableOnContentEditable: true,
   enableOnFormTags: true,
@@ -143,11 +154,7 @@ function RootLayout() {
       }
     });
 
-    return () => {
-      unlisten.then((dispose) => {
-        dispose();
-      });
-    };
+    return disposeLater(unlisten);
   }, [queryClient]);
 
   // Tray menu + "Open With" plumbing from Rust.
@@ -183,14 +190,7 @@ function RootLayout() {
 
     drainPendingOpens().catch(reportFailure("could not open file"));
 
-    return () => {
-      unlistenNew.then((dispose) => {
-        dispose();
-      });
-      unlistenOpen.then((dispose) => {
-        dispose();
-      });
-    };
+    return disposeLater(unlistenNew, unlistenOpen);
   }, []);
 
   // Quit is held open by Rust until the buffers are on disk -- and called off
@@ -223,11 +223,7 @@ function RootLayout() {
         });
     });
 
-    return () => {
-      unlisten.then((dispose) => {
-        dispose();
-      });
-    };
+    return disposeLater(unlisten);
   }, []);
 
   useHotkeys(

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,9 +1,10 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import {
-  createRootRoute,
+  createRootRouteWithContext,
   Navigate,
   Outlet,
   useNavigate,
-  useRouter,
 } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -14,36 +15,40 @@ import { SettingsDialog } from "@/components/settings-dialog";
 import { Toaster, toast } from "@/components/ui/toast";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { createNote } from "@/data/create-note";
-import { getFolders } from "@/data/get-folders";
-import { getNotes } from "@/data/get-notes";
-import { getTags } from "@/data/get-tags";
-import { getNotesDir } from "@/data/notes-dir";
+import { noteQueries, notesDirQuery } from "@/data/queries";
 import { flushPendingWrites } from "@/lib/pending-flush";
-import { bumpRevision, openNote, openTab, persistTabs } from "@/lib/tabs/store";
+import { openNote, openTab, persistTabs } from "@/lib/tabs/store";
 import { errorMessage } from "@/lib/ui/failure";
 import { findUpdate, offerUpdate, updatesSupported } from "@/lib/updater";
+
+/** Cached data answers the loader; only a cold key fetches. */
+const STATIC = "static" as const;
 
 interface RootSearch {
   /** Set by a tag chip to open the palette already filtered to that tag. */
   tag?: string;
 }
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<{
+  queryClient: QueryClient;
+}>()({
   component: RootLayout,
   // The workspace is the only screen (`D53`), so any other path is a stale URL
   // -- a dev reload holding the retired `/notes/$`, or a malformed deep link.
   notFoundComponent: () => <Navigate replace to="/" />,
   validateSearch: (search: Record<string, unknown>): RootSearch =>
     typeof search.tag === "string" ? { tag: search.tag } : {},
-  loader: async () => {
-    const [notes, folders, notesDir, tags] = await Promise.all([
-      getNotes(),
-      getFolders(),
-      getNotesDir(),
-      getTags(),
+  // Priming only: an inactive query is one invalidation cannot reach.
+  loader: async ({ context }) => {
+    await Promise.all([
+      context.queryClient.query({
+        ...noteQueries.folders(),
+        staleTime: STATIC,
+      }),
+      context.queryClient.query({ ...noteQueries.list(), staleTime: STATIC }),
+      context.queryClient.query({ ...noteQueries.tags(), staleTime: STATIC }),
+      context.queryClient.query({ ...notesDirQuery, staleTime: STATIC }),
     ]);
-
-    return { folders, notes, notesDir, tags };
   },
 });
 
@@ -54,10 +59,13 @@ const HOTKEY_OPTIONS = {
 } as const;
 
 function RootLayout() {
-  const { folders, notes, notesDir, tags } = Route.useLoaderData();
+  const { data: folders } = useSuspenseQuery(noteQueries.folders());
+  const { data: notes } = useSuspenseQuery(noteQueries.list());
+  const { data: notesDir } = useSuspenseQuery(notesDirQuery);
+  const { data: tags } = useSuspenseQuery(noteQueries.tags());
   const { tag } = Route.useSearch();
-  const router = useRouter();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -115,10 +123,24 @@ function RootLayout() {
   }, []);
 
   // External writers (AI agents, other editors, the watcher) drive refreshes.
+  // No paths means the whole vault.
   useEffect(() => {
-    const unlisten = listen("notes-changed", () => {
-      router.invalidate();
-      bumpRevision();
+    const unlisten = listen<{ paths: string[] }>("notes-changed", (event) => {
+      const { paths } = event.payload;
+
+      if (paths.length === 0) {
+        queryClient.invalidateQueries({ queryKey: noteQueries.all });
+
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: noteQueries.index });
+
+      for (const path of paths) {
+        queryClient.invalidateQueries({
+          queryKey: noteQueries.fileKey("note", path),
+        });
+      }
     });
 
     return () => {
@@ -126,7 +148,7 @@ function RootLayout() {
         dispose();
       });
     };
-  }, [router]);
+  }, [queryClient]);
 
   // Tray menu + "Open With" plumbing from Rust.
   useEffect(() => {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,8 +1,5 @@
-import {
-  createFileRoute,
-  getRouteApi,
-  useNavigate,
-} from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -17,11 +14,12 @@ import { NoteSession } from "@/components/workspace/note-session";
 import { attachFile } from "@/data/attach-file";
 import { createNote } from "@/data/create-note";
 import { getNotes } from "@/data/get-notes";
+import { noteQueries } from "@/data/queries";
 import { togglePref, usePref } from "@/lib/prefs";
 import {
   activateTab,
   closeTab,
-  getTabSnapshot,
+  getTabHandles,
   getTabState,
   moveTab,
   openNote,
@@ -35,12 +33,9 @@ import { stepTab, tabId } from "@/lib/tabs/tab";
 import { errorMessage } from "@/lib/ui/failure";
 import { attachmentLink } from "@/lib/utils/attachments";
 
-const rootApi = getRouteApi("__root__");
-
 /**
- * Restoring is a launch behaviour, not a refresh one. The loader re-runs on
- * every `notes-changed`, and without this a closed last tab would reopen
- * itself the next time an agent touched the folder.
+ * Restoring is a launch behaviour. Anything that re-runs the loader afterwards
+ * must not reopen a tab the user closed.
  */
 let seeded = false;
 
@@ -170,7 +165,7 @@ function ActiveStatusBar({
 function Workspace() {
   const { activeId, tabs } = useTabState();
   const navigate = useNavigate();
-  const { tags } = rootApi.useLoaderData();
+  const { data: tags } = useSuspenseQuery(noteQueries.tags());
 
   const activeTab = tabs.find((tab) => tabId(tab) === activeId);
 
@@ -192,7 +187,7 @@ function Workspace() {
   }, []);
 
   const toggleSource = useCallback(() => {
-    getTabSnapshot(getTabState().activeId)?.toggleSource();
+    getTabHandles(getTabState().activeId)?.toggleSource();
   }, []);
 
   const toggleFocusMode = useCallback(() => {
@@ -214,7 +209,7 @@ function Workspace() {
   // whichever tab is showing.
   useEffect(() => {
     const attachDropped = async (paths: string[]) => {
-      const target = getTabSnapshot(getTabState().activeId);
+      const target = getTabHandles(getTabState().activeId);
 
       if (target === undefined) {
         toast.add({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster, cached loading for notes, folders, and tags across the workspace.
  * Search results remain visible while updated results load.
  * Improved link-editor reopening and code-copy feedback.
  * Tag edits are saved in order, preserving the latest changes.

* **Bug Fixes**
  * External file changes now refresh only affected tabs.
  * Improved recovery when note reads fail or files are renamed.
  * Settings errors provide clearer feedback and restore the actual system state.
  * Prevented stale tag updates from overwriting newer changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->