### PR TITLE
test: ✅ cover autosave write serialization

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -6,7 +6,7 @@ This file is a log, not a set of rules. An entry records what was decided and wh
 
 A **Constraint:** line reads closest to an order and is not one. It names what the decision left the codebase carrying, and it holds only as long as that decision does.
 
-Numbering is monotonic and IDs are never reused, even after an entry is removed. A citation in a commit or a comment outlives the line it points at, so reusing an ID repoints every reference to it without any of them changing. The highest number issued so far is 69, and some entries below it were removed, so the next entry takes 70.
+Numbering is monotonic and IDs are never reused, even after an entry is removed. A citation in a commit or a comment outlives the line it points at, so reusing an ID repoints every reference to it without any of them changing. The highest number issued so far is 70, and some entries below it were removed, so the next entry takes 71.
 
 An entry belongs here when picking one option ruled out another for a reason worth recording. A rule that must hold, with no competing option anyone would weigh, is an invariant and lives in `ARCHITECTURE.md`.
 

--- a/src/components/editor/use-autosave.spec.ts
+++ b/src/components/editor/use-autosave.spec.ts
@@ -87,6 +87,25 @@ function mountAutosave(
         await vi.advanceTimersByTimeAsync(AUTOSAVE_DELAY_MS);
       });
     },
+    /**
+     * Start a flush and hand its promise back, so a second flush can be
+     * started while the first write is still in flight. Deliberately not
+     * `async`: an async method would adopt the promise it returns and wait for
+     * the write, which is the opposite of what a caller wants here.
+     */
+    startFlush() {
+      let pending: Promise<boolean> | undefined;
+
+      act(() => {
+        pending = live.flush();
+      });
+
+      if (pending === undefined) {
+        throw new Error("the flush never started");
+      }
+
+      return pending;
+    },
     get status() {
       return live.status;
     },
@@ -202,6 +221,110 @@ describe("useAutosave", () => {
       "first",
       "first, plus everything typed while the file was gone",
     ]);
+
+    harness.unmount();
+  });
+
+  it("should land overlapping writes in the order they were flushed", async () => {
+    const written: string[] = [];
+    const landWrite: Array<() => void> = [];
+    const harness = mountAutosave((_path, content) => {
+      written.push(content);
+
+      return new Promise<Date>((resolve) => {
+        landWrite.push(() => {
+          resolve(new Date(1));
+        });
+      });
+    });
+
+    /** Run every chain link that can run, without landing a write. */
+    const advance = async () => {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    };
+
+    /** Let the write the fake is holding at `index` resolve. */
+    const land = async (index: number) => {
+      const resolve = landWrite[index];
+
+      if (resolve === undefined) {
+        throw new Error(`write ${index} never reached the fake`);
+      }
+
+      resolve();
+      await advance();
+    };
+
+    harness.type("first");
+    const firstFlush = harness.startFlush();
+    await advance();
+
+    // The first write is in flight, which is the only window in which a second
+    // flush can overlap it. A keystroke before this one would be coalesced.
+    expect(written).toStrictEqual(["first"]);
+
+    harness.type("second");
+    const secondFlush = harness.startFlush();
+    await advance();
+
+    // The second flush waits on the first rather than racing it, so the fake
+    // is still holding one write.
+    expect(written).toStrictEqual(["first"]);
+
+    await land(0);
+
+    expect(written).toStrictEqual(["first", "second"]);
+
+    await land(1);
+
+    await expect(firstFlush).resolves.toBe(true);
+    await expect(secondFlush).resolves.toBe(true);
+    expect(harness.status).toBe("saved");
+
+    harness.unmount();
+  });
+
+  it("should write again after a write fails", async () => {
+    const written: string[] = [];
+    let failNext = true;
+    const harness = mountAutosave((_path, content) => {
+      written.push(content);
+
+      if (failNext) {
+        failNext = false;
+
+        return Promise.reject(new Error("the disk said no"));
+      }
+
+      return Promise.resolve(new Date(1));
+    });
+
+    harness.type("hello");
+    await harness.settle();
+
+    expect(written).toStrictEqual(["hello"]);
+    expect(harness.status).toBe("failed");
+
+    // The failed write handed its content back, and the chain still runs.
+    await expect(harness.flush()).resolves.toBe(true);
+    expect(written).toStrictEqual(["hello", "hello"]);
+    expect(harness.status).toBe("saved");
+
+    harness.unmount();
+  });
+
+  it("should report the buffer unsafe to quit when its write fails", async () => {
+    const harness = mountAutosave(() =>
+      Promise.reject(new Error("the disk said no"))
+    );
+
+    harness.type("hello");
+
+    // This false is what cancels a quit, unlike the one a gone file reports.
+    await expect(harness.flush()).resolves.toBe(false);
+    expect(harness.status).toBe("failed");
 
     harness.unmount();
   });


### PR DESCRIPTION
## What

Three tests in `src/components/editor/use-autosave.spec.ts`, and no production code change.

The first interleaves two flushes across an in-flight write: it types, flushes, lets the write reach the fake, then types and flushes again, and asserts the second write has not started until the first lands. `mountAutosave` gains one method for it, `startFlush`, which hands a flush promise back without waiting on it.

The second takes a write through a failure and out the other side, covering the buffer restore at `use-autosave.ts:89`. The third checks the `false` that `flushPendingWrites()` turns into a cancelled quit. No `write` fake in this spec had ever rejected before these two.

Also corrects `DECISIONS.md:9`, which still said the highest ID issued was 69 and the next entry takes 70. D70 landed in #133 without touching it.

## Why

`SPEC.md:33` claims writes are serialized so two flushes cannot land out of order, and `ARCHITECTURE.md:204` restates it as an invariant. Nothing asserted it. `SPEC.md:124`'s "a buffer that could not write cancels the quit" was unasserted too. `SPEC.md`'s own framing says a claim nobody can check does not belong there, and these were checkable only by reading `chainWrite`.

When serialization breaks, two writes for the same buffer land out of order and the older one wins, so a note loses the last thing typed into it while the glyph reads saved. The signal is now a red test: deleting the chain and returning `writeOnce()` directly makes the ordering test fail with `expected [ 'first', 'second' ] to strictly equal [ 'first' ]`, which was run before this was raised.

The `DECISIONS.md` line is a symptom-layer fix and the root cause stays open. The counter is maintained by hand with nothing checking it. Deriving it from a grep over the `### D` headings would understate the next ID whenever the highest entry is one of the removed ones, and the repo has no docs check to hang enforcement on, the same reason `D43` leaves the layer boundaries to a reviewer. If it drifts again the signal is a new entry whose number collides with a heading already in the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for overlapping autosave operations to ensure writes complete in the correct order.
  - Added tests verifying autosave retries after a failed write.
  - Added coverage for reporting unsaved changes safely when writes fail.

- **Documentation**
  - Updated the decision log’s numbering record for the next available entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->