### PR TITLE
feat: ✨ add keys to command palette

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -100,6 +100,7 @@ Motion carries a state change and nothing else. There is no decorative animation
 - **The palette is the action surface.** A new note-level action goes in ⌘K rather than into new chrome. `ARCHITECTURE.md` lists what it holds.
 - **`·` joins related metadata.** The status strip reads `214 words · 1 min`, a palette row reads `title · folder`. Use the middot rather than a pipe, a dash, or a second line.
 - **Floating surfaces share one recipe.** Suggestion menus and the link editor are `position: fixed`, `z-index: 50`, bordered, on `--popover`, with `0 8px 24px rgb(0 0 0 / 0.18)`. Menus clamp to the viewport rather than overflowing it.
+- **A chord on screen is drawn by `Chord` from a hotkey, never typed as a glyph.** `src/components/chord.tsx` formats it for the running platform, so `Mod+Shift+N` renders `⌘⇧n` here and `ctrl+shift+n` where the symbols do not exist. A surface that already names an action, such as a palette row, finds its chords through `useChordsByName` instead of carrying them.
 - **Shortcuts live in `README.md`.** That table is the one a person looks up, so it is the one that gets extended. Adding a shortcut here as well is how the two drift.
 
 ## The editor surface

--- a/SPEC.md
+++ b/SPEC.md
@@ -78,6 +78,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - `#` alone lists matching tags with their counts, and picking one rewrites the query.
 - The actions are new note, pin, edit tags, rename note, move to folder, delete note, reveal in finder, toggle typewriter scrolling, settings, reindex library, and check for updates. Every one but new note, settings, reindex library, and check for updates needs a note showing.
 - Actions match the free text after a tag token, so they stay reachable inside a tag filter.
+- An action that has a shortcut shows it on its row, read from the bindings the app has registered rather than restated: new note carries ⌘n and ⌘t, edit tags ⌘⇧y, toggle typewriter scrolling ⌘⌥t, and settings ⌘,. The rest show none.
 
 ## The editor
 

--- a/src/components/capture-window.tsx
+++ b/src/components/capture-window.tsx
@@ -2,10 +2,10 @@ import { useHotkeys } from "@tanstack/react-hotkeys";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { format } from "date-fns";
 import { useCallback, useRef, useState } from "react";
+import { Chord } from "@/components/chord";
 import type { EditorHandle } from "@/components/editor/editor";
 import { Editor } from "@/components/editor/editor";
 import { Titlebar } from "@/components/titlebar";
-import { Kbd } from "@/components/ui/kbd";
 import { Toaster, toast } from "@/components/ui/toast";
 import { createNote } from "@/data/create-note";
 import { errorMessage } from "@/lib/ui/failure";
@@ -78,7 +78,7 @@ export function CaptureWindow() {
         placeholderText="jot it down..."
       />
       <footer className="flex h-7 shrink-0 items-center justify-end gap-2 border-t px-3 text-muted-foreground text-xs">
-        <Kbd>esc</Kbd> saves to inbox
+        <Chord hotkey="Escape" /> saves to inbox
       </footer>
       {/* This window bypasses the router, so it needs its own Toaster. */}
       <Toaster />

--- a/src/components/chord.tsx
+++ b/src/components/chord.tsx
@@ -2,11 +2,12 @@ import { Kbd } from "@/components/ui/kbd";
 import { chordGlyph } from "@/lib/ui/shortcuts";
 
 interface ChordProps {
+  className?: string;
   /** A registered hotkey, e.g. `Mod+Shift+Y`, drawn for the running platform. */
   hotkey: string;
 }
 
 /** One chord, one box. */
-export function Chord({ hotkey }: ChordProps) {
-  return <Kbd>{chordGlyph(hotkey)}</Kbd>;
+export function Chord({ className, hotkey }: ChordProps) {
+  return <Kbd className={className}>{chordGlyph(hotkey)}</Kbd>;
 }

--- a/src/components/chord.tsx
+++ b/src/components/chord.tsx
@@ -1,0 +1,12 @@
+import { Kbd } from "@/components/ui/kbd";
+import { chordGlyph } from "@/lib/ui/shortcuts";
+
+interface ChordProps {
+  /** A registered hotkey, e.g. `Mod+Shift+Y`, drawn for the running platform. */
+  hotkey: string;
+}
+
+/** One chord, one box. */
+export function Chord({ hotkey }: ChordProps) {
+  return <Kbd>{chordGlyph(hotkey)}</Kbd>;
+}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -19,6 +19,7 @@ import {
   Trash2Icon,
 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
+import { Chord } from "@/components/chord";
 import { useNoteTags } from "@/components/notes/use-note-tags";
 import {
   Command,
@@ -29,6 +30,7 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
+  CommandShortcut,
 } from "@/components/ui/command";
 import { toast } from "@/components/ui/toast";
 import type { NoteMeta } from "@/core/notes";
@@ -49,6 +51,7 @@ import {
 } from "@/lib/tabs/store";
 import { tabId } from "@/lib/tabs/tab";
 import { errorMessage } from "@/lib/ui/failure";
+import { useChordsByName } from "@/lib/ui/shortcuts";
 import { findUpdate, offerUpdate, updatesSupported } from "@/lib/updater";
 import { getSnippetParts } from "@/lib/utils/fts-snippet";
 import { parseTagQuery } from "@/lib/utils/tag-query";
@@ -440,6 +443,7 @@ export function CommandPalette({
   const { activeId, tabs } = useTabState();
   // Note actions act on the tab that is showing, and only when it holds a note:
   // an external file carries no frontmatter to pin, tag, rename or move.
+  const chordsByName = useChordsByName();
   const activeTab = tabs.find((tab) => tabId(tab) === activeId);
   const currentPath = activeTab?.kind === "note" ? activeTab.path : undefined;
   const currentNote = notes.find((note) => note.path === currentPath);
@@ -875,12 +879,27 @@ export function CommandPalette({
                       (!action.needsNote || currentNote !== undefined) &&
                       matchesQuery(action.label)
                   )
-                  .map(({ Icon, onSelect, text, value }) => (
-                    <CommandItem key={value} onSelect={onSelect} value={value}>
-                      <Icon />
-                      {text}
-                    </CommandItem>
-                  ))}
+                  .map(({ Icon, label, onSelect, text, value }) => {
+                    const chords = chordsByName.get(label);
+
+                    return (
+                      <CommandItem
+                        key={value}
+                        onSelect={onSelect}
+                        value={value}
+                      >
+                        <Icon />
+                        {text}
+                        {chords === undefined ? null : (
+                          <CommandShortcut>
+                            {chords.map(({ hotkey, id }) => (
+                              <Chord hotkey={hotkey} key={id} />
+                            ))}
+                          </CommandShortcut>
+                        )}
+                      </CommandItem>
+                    );
+                  })}
                 {matchesQuery("search") && query.trim() === "" ? (
                   <CommandItem disabled value="search-hint">
                     <SearchIcon />

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -893,7 +893,13 @@ export function CommandPalette({
                         {chords === undefined ? null : (
                           <CommandShortcut>
                             {chords.map(({ hotkey, id }) => (
-                              <Chord hotkey={hotkey} key={id} />
+                              // A selected row is `bg-muted`, which the chip
+                              // otherwise matches exactly and disappears into.
+                              <Chord
+                                className="tracking-normal group-data-selected/command-item:bg-background"
+                                hotkey={hotkey}
+                                key={id}
+                              />
                             ))}
                           </CommandShortcut>
                         )}

--- a/src/components/notes/note-tags.tsx
+++ b/src/components/notes/note-tags.tsx
@@ -48,9 +48,13 @@ export function NoteTags({ allTags, onFilter, path, tags }: NoteTagsProps) {
   const [query, setQuery] = useState("");
   const { changeTags, tags: optimisticTags } = useNoteTags(path, tags);
 
-  useHotkey("Mod+Shift+Y", () => {
-    setOpen(true);
-  });
+  useHotkey(
+    "Mod+Shift+Y",
+    () => {
+      setOpen(true);
+    },
+    { meta: { name: "edit tags" } }
+  );
 
   const counts = new Map(allTags.map(({ count, tag }) => [tag, count]));
 

--- a/src/components/notes/status-bar.tsx
+++ b/src/components/notes/status-bar.tsx
@@ -1,8 +1,8 @@
 import { CodeIcon, CrosshairIcon, KeyboardIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
 
+import { Chord } from "@/components/chord";
 import { NoteTags } from "@/components/notes/note-tags";
-import { Kbd } from "@/components/ui/kbd";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
   Tooltip,
@@ -44,7 +44,7 @@ export function StatusBar({
   const toggles = useMemo(
     () => [
       {
-        hint: "⌘d",
+        hotkey: "Mod+D",
         icon: CrosshairIcon,
         label: "focus mode",
         onToggle: onToggleFocusMode,
@@ -52,7 +52,7 @@ export function StatusBar({
         value: "focus",
       },
       {
-        hint: "⌘⌥t",
+        hotkey: "Mod+Alt+T",
         icon: KeyboardIcon,
         label: "typewriter scrolling",
         onToggle: onToggleTypewriter,
@@ -60,7 +60,7 @@ export function StatusBar({
         value: "typewriter",
       },
       {
-        hint: "⌘p",
+        hotkey: "Mod+P",
         icon: CodeIcon,
         label: "markdown source",
         onToggle: onToggleSource,
@@ -109,7 +109,7 @@ export function StatusBar({
           .filter((toggle) => toggle.pressed)
           .map((toggle) => toggle.value)}
       >
-        {toggles.map(({ hint, icon: Icon, label, value }) => (
+        {toggles.map(({ hotkey, icon: Icon, label, value }) => (
           <Tooltip key={value}>
             <TooltipTrigger
               render={
@@ -123,7 +123,7 @@ export function StatusBar({
               <Icon className={CHROME_GLYPH} />
             </TooltipTrigger>
             <TooltipContent>
-              {label} {hint === "" ? null : <Kbd>{hint}</Kbd>}
+              {label} <Chord hotkey={hotkey} />
             </TooltipContent>
           </Tooltip>
         ))}

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -7,6 +7,7 @@ import {
 import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect } from "react";
+import { Chord } from "@/components/chord";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,7 +16,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Kbd } from "@/components/ui/kbd";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/toast";
@@ -141,7 +141,7 @@ export function SettingsDialog({
             />
           </div>
           <p className="text-muted-foreground text-xs">
-            quick capture from anywhere with <Kbd>⌘⇧n</Kbd>
+            quick capture from anywhere with <Chord hotkey="Mod+Shift+N" />
           </p>
         </div>
       </DialogContent>

--- a/src/lib/ui/shortcuts.spec.tsx
+++ b/src/lib/ui/shortcuts.spec.tsx
@@ -1,0 +1,106 @@
+import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { chordGlyph, useChordsByName } from "./shortcuts";
+
+// `act` refuses to run without this, and no setup file exists to set it.
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const NOOP = () => undefined;
+
+let teardown: (() => void) | null = null;
+
+afterEach(() => {
+  teardown?.();
+  teardown = null;
+});
+
+/**
+ * Registers a named pair and a nameless binding, then reads the lookup back
+ * from a child. Reading it in the registering component would never settle,
+ * which is also how the app is arranged: the palette reads, the routes
+ * register.
+ */
+const mountLookup = async () => {
+  // A plain `let` assigned only inside the child narrows to `never` at the
+  // read below, since the compiler cannot see the closure write.
+  const captured: { value: ReturnType<typeof useChordsByName> | null } = {
+    value: null,
+  };
+
+  function Reader() {
+    captured.value = useChordsByName();
+
+    return null;
+  }
+
+  function Fixture() {
+    useHotkeys(
+      [
+        { callback: NOOP, hotkey: "Mod+N" },
+        { callback: NOOP, hotkey: "Mod+T" },
+      ],
+      { meta: { name: "new note" } }
+    );
+    useHotkey("Mod+W", NOOP);
+
+    return createElement(Reader);
+  }
+
+  const host = document.createElement("div");
+
+  document.body.append(host);
+
+  const root = createRoot(host);
+
+  await act(async () => {
+    root.render(createElement(Fixture));
+    await Promise.resolve();
+  });
+
+  teardown = () => {
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
+  };
+
+  const { value } = captured;
+
+  if (value === null) {
+    throw new Error("the lookup never rendered");
+  }
+
+  return value;
+};
+
+describe("chord glyph", () => {
+  it("should separate the segments the platform needs a separator for", () => {
+    // happy-dom does not report macOS, so this is the word-label branch, where
+    // dropping the separator would read `ctrlshiftk`.
+    expect(chordGlyph("Mod+Shift+K")).toBe("ctrl+shift+k");
+  });
+
+  it("should print a single key with no separator", () => {
+    expect(chordGlyph("Escape")).toBe("esc");
+  });
+});
+
+describe("chords by name", () => {
+  it("should collect every chord registered under one name", async () => {
+    const chords = await mountLookup();
+
+    expect(chords.get("new note")?.map(({ hotkey }) => hotkey)).toStrictEqual([
+      "Mod+N",
+      "Mod+T",
+    ]);
+  });
+
+  it("should leave a name nothing registered absent", async () => {
+    const chords = await mountLookup();
+
+    expect(chords.get("close tab")).toBeUndefined();
+  });
+});

--- a/src/lib/ui/shortcuts.ts
+++ b/src/lib/ui/shortcuts.ts
@@ -1,0 +1,36 @@
+import {
+  detectPlatform,
+  formatForDisplay,
+  useHotkeyRegistrations,
+} from "@tanstack/react-hotkeys";
+
+/**
+ * A chord as the interface prints it, lowercase throughout.
+ *
+ * The separator follows the platform rather than being dropped: mac renders
+ * symbols, which separate themselves, but the word labels everywhere else run
+ * together without one, so `Mod+Shift+K` would read `ctrlshiftk`.
+ */
+export function chordGlyph(hotkey: string) {
+  const platform = detectPlatform();
+
+  return formatForDisplay(hotkey, {
+    platform,
+    separatorToken: platform === "mac" ? "" : "+",
+  }).toLowerCase();
+}
+
+/**
+ * Every live binding, keyed by the action name its `meta` carries, so a
+ * surface that already names an action can find its chords without
+ * restating them. An action with no binding is simply absent.
+ *
+ * Never call this from a component that also registers a hotkey. `useHotkey`
+ * syncs its options on every render and that write always builds a new
+ * registration map, so a component doing both wakes itself and never settles.
+ */
+export function useChordsByName() {
+  const { hotkeys } = useHotkeyRegistrations();
+
+  return Map.groupBy(hotkeys, ({ options }) => options.meta?.name);
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -223,21 +223,29 @@ function RootLayout() {
   useHotkey("Mod+K", () => {
     setPaletteOpen((current) => !current);
   });
-  useHotkey("Mod+N", async () => {
-    try {
-      const path = await createNote();
+  useHotkey(
+    "Mod+N",
+    async () => {
+      try {
+        const path = await createNote();
 
-      openNote(path, true);
-    } catch (error) {
-      toast.add({
-        title: errorMessage(error, "could not create note"),
-        type: "error",
-      });
-    }
-  });
-  useHotkey("Mod+,", () => {
-    setSettingsOpen(true);
-  });
+        openNote(path, true);
+      } catch (error) {
+        toast.add({
+          title: errorMessage(error, "could not create note"),
+          type: "error",
+        });
+      }
+    },
+    { meta: { name: "new note" } }
+  );
+  useHotkey(
+    "Mod+,",
+    () => {
+      setSettingsOpen(true);
+    },
+    { meta: { name: "settings" } }
+  );
 
   return (
     <TooltipProvider>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,12 +3,12 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect } from "react";
+import { Chord } from "@/components/chord";
 import { NoteControls } from "@/components/notes/note-controls";
 import { StatusBar } from "@/components/notes/status-bar";
 import { TabStrip } from "@/components/tabs/tab-strip";
 import { Titlebar } from "@/components/titlebar";
 import { Button } from "@/components/ui/button";
-import { Kbd } from "@/components/ui/kbd";
 import { toast } from "@/components/ui/toast";
 import { NoteSession } from "@/components/workspace/note-session";
 import { attachFile } from "@/data/attach-file";
@@ -83,11 +83,11 @@ function EmptyState({ onNew }: { onNew: () => void }) {
         <p className="text-muted-foreground">just write, otra vez.</p>
       </div>
       <div className="flex items-center gap-4 text-muted-foreground text-sm">
-        <Button onClick={onNew} variant="secondary">
-          new note <Kbd>⌘n</Kbd>
+        <Button onClick={onNew} variant="outline">
+          new note <Chord hotkey="Mod+N" />
         </Button>
         <span>
-          or search with <Kbd>⌘k</Kbd>
+          or search with <Chord hotkey="Mod+K" />
         </span>
       </div>
     </div>
@@ -283,12 +283,14 @@ function Workspace() {
     }
   }, []);
 
-  useHotkey("Mod+T", newNote);
+  useHotkey("Mod+T", newNote, { meta: { name: "new note" } });
   useHotkey("Mod+W", closeActive);
   useHotkey("Mod+Shift+T", reopenTab);
   useHotkey("Mod+P", toggleSource);
   useHotkey("Mod+D", toggleFocusMode);
-  useHotkey("Mod+Alt+T", toggleTypewriter);
+  useHotkey("Mod+Alt+T", toggleTypewriter, {
+    meta: { name: "typewriter scrolling" },
+  });
   useHotkeys(
     TAB_JUMPS.map(([hotkey, index]) => ({
       callback: () => jumpToTab(index),

--- a/src/styles.css
+++ b/src/styles.css
@@ -73,7 +73,7 @@
   --secondary: #2c2e30;
   --secondary-foreground: #e9ebee;
   --muted: #2c2e30;
-  --muted-foreground: #848688;
+  --muted-foreground: #939597;
   --accent: #2c2e30;
   --accent-foreground: #e9ebee;
   --destructive: #e76761;
@@ -110,7 +110,7 @@
     --secondary: #d5d8db;
     --secondary-foreground: #2a2e33;
     --muted: #d5d8db;
-    --muted-foreground: #707274;
+    --muted-foreground: #5c5e60;
     --accent: #d5d8db;
     --accent-foreground: #2a2e33;
     --destructive: #b64340;

--- a/src/styles.spec.ts
+++ b/src/styles.spec.ts
@@ -104,13 +104,19 @@ const SYNTAX = [
  * `--card` while source mode is transparent onto `--background`, so the syntax
  * ramp is painted on both and has to clear the floor on both. `--muted` carries
  * the inline-code chip Typeset paints (`D40`), which body text and a muted
- * heading both sit inside.
+ * heading both sit inside, and the `Kbd` chip, whose own text is
+ * `--muted-foreground`.
+ *
+ * That last pair is cleared by moving `--muted-foreground`, never `--muted`:
+ * light would need `--muted` at `#f5f8fb`, which is indistinguishable from
+ * `--background`, and the chip would lose its box against the page.
  */
 const PAIRS: [text: string, surface: string][] = [
   ["foreground", "background"],
   ["card-foreground", "card"],
   ["popover-foreground", "popover"],
   ["foreground", "muted"],
+  ["muted-foreground", "muted"],
   ["muted-foreground", "background"],
   ["muted-foreground", "card"],
   ["muted-foreground", "popover"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command and palette actions now display registered keyboard shortcuts.
  * Shortcut hints use platform-appropriate key symbols throughout the app.
  * Updated shortcut labels for note creation, tag editing, typewriter scrolling, and settings.

* **Style**
  * Improved muted text contrast across light and dark themes.
  * Updated the empty-state action button styling.

* **Tests**
  * Added coverage for platform-specific shortcut formatting and shortcut registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->