### PR TITLE
fix: 🐛 strikethrough does not escape

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -879,3 +879,4 @@ The tab module splits into two stores. `tabs` holds the open set and the active 
 **Constraint:** no `compare` is passed to `useSelector`. The default is `Object.is`, and `publishTabSnapshot` stores the object the session hands it, so a tab nobody touched returns the same reference and bails. `shallow` here would re-render every session on every keystroke, the trap `D68` recorded for Pacer.
 
 **Constraint:** the swap costs 84 bytes gzipped, measured by building the same tree both ways (`index` +84; `routes`, the CSS and the fonts do not move). No package is added to the lockfile: `@tanstack/react-store` was already resolved at 0.11.1 for Pacer and Hotkeys, and the direct dependency pins that copy.
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -97,6 +97,8 @@ What notras does. Every claim below is checkable against a running build, so a c
 - Pasting an image saves `attachments/pasted-<epoch-ms>.png`.
 - Pasting text that looks like markdown pastes rich. Anything else pastes plain. Copying out of the editor puts markdown on the clipboard.
 - Tables are editable and start at two columns by three rows with a header. Task checkboxes are clickable and round-trip as `- [x]` and `- [ ]`.
+- Strikethrough takes one tilde or two, typed or read from a file, and the closing run may not follow a space. The serializer writes two, so `~x~` in a note written elsewhere saves back as `~~x~~`.
+- A literal `` ` ``, `*`, `_`, `[`, `]` or `~` in prose is written to the file as typed. It gains a backslash only where the note would otherwise read back as something else, and then the whole note is escaped.
 - A code block carries a copy button and a language picker. The picker keeps a language lowlight does not know rather than rewriting it, and markdown highlights a leading frontmatter block as YAML.
 - ⌘D toggles focus mode, which drops every block but the one holding the caret to 28% opacity.
 - Scrolling by wheel or touch lifts the dim so the rest of the note reads normally, and typing, arrow travel, or a click restores it. Dragging the scrollbar does not lift it.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tiptap/extension-image": "3.30.5",
     "@tiptap/extension-link": "3.30.5",
     "@tiptap/extension-paragraph": "3.30.5",
+    "@tiptap/extension-strike": "3.30.5",
     "@tiptap/extension-table": "3.30.5",
     "@tiptap/extension-task-item": "3.30.5",
     "@tiptap/extension-task-list": "3.30.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@tiptap/extension-paragraph':
         specifier: 3.30.5
         version: 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
+      '@tiptap/extension-strike':
+        specifier: 3.30.5
+        version: 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))
       '@tiptap/extension-table':
         specifier: 3.30.5
         version: 3.30.5(@tiptap/core@3.30.5(@tiptap/pm@3.30.5))(@tiptap/pm@3.30.5)

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/ui/utils";
 import { encodeAttachmentPath } from "@/lib/utils/attachments";
 import {
   createEditorExtensions,
+  fileMarkdown,
   normalizeMarkdown,
   serializeMarkdown,
 } from "./extensions";
@@ -147,7 +148,12 @@ export function Editor({
           const doc = view.state.schema.topNodeType.create(null, slice.content);
           const manager = editorRef.current?.markdown;
 
-          return manager ? manager.serialize(doc.toJSON()) : fallback;
+          return manager
+            ? fileMarkdown(
+                manager,
+                normalizeMarkdown(manager.serialize(doc.toJSON()))
+              )
+            : fallback;
         } catch {
           return fallback;
         }
@@ -304,7 +310,10 @@ export function Editor({
             );
             const md: string = manager.serialize(marked.doc.toJSON());
 
-            return normalizeMarkdown(md).indexOf(SENTINEL);
+            // Source mode shows the file form, so the offset has to index it.
+            return fileMarkdown(manager, normalizeMarkdown(md)).indexOf(
+              SENTINEL
+            );
           } catch {
             return -1;
           }
@@ -361,7 +370,10 @@ export function Editor({
       const diverged = (() => {
         try {
           const canonical = manager
-            ? normalizeMarkdown(manager.serialize(manager.parse(cleanBody)))
+            ? fileMarkdown(
+                manager,
+                normalizeMarkdown(manager.serialize(manager.parse(cleanBody)))
+              )
             : serializeMarkdown(editor);
 
           // Trailing whitespace differs benignly (StarterKit's

--- a/src/components/editor/extensions.spec.ts
+++ b/src/components/editor/extensions.spec.ts
@@ -97,6 +97,14 @@ describe("strike input rule", () => {
     expect(typeInto("drop ~this~ one")).toBe("drop ~~this~~ one");
   });
 
+  it("should strike a span typed with one tilde after a word", () => {
+    expect(typeInto("word~x~")).toBe("word~~x~~");
+  });
+
+  it("should strike a span typed with one tilde before a word", () => {
+    expect(typeInto("~x~word")).toBe("~~x~~word");
+  });
+
   it("should leave a tilde with no closer as typed", () => {
     expect(typeInto("takes ~5 minutes")).toBe("takes ~5 minutes");
   });

--- a/src/components/editor/extensions.spec.ts
+++ b/src/components/editor/extensions.spec.ts
@@ -1,7 +1,7 @@
 import { Editor } from "@tiptap/core";
 import { describe, expect, it } from "vitest";
 
-import { createEditorExtensions } from "./extensions";
+import { createEditorExtensions, serializeMarkdown } from "./extensions";
 
 /**
  * The task-list CSS reaches a row as `ul[data-type="taskList"] > li` (`D39`),
@@ -54,5 +54,54 @@ describe("task item DOM", () => {
 
     expect(row?.matches('li[data-checked="true"]')).toBe(true);
     expect(row?.matches('li[data-type="taskItem"]')).toBe(false);
+  });
+});
+
+const typeInto = (text: string) => {
+  const editor = new Editor({
+    content: "",
+    contentType: "markdown",
+    element: document.createElement("div"),
+    extensions: createEditorExtensions({}),
+  });
+
+  for (const char of text) {
+    const { from, to } = editor.state.selection;
+    const insert = () => editor.state.tr.insertText(char, from, to);
+    const handled = editor.view.someProp("handleTextInput", (input) =>
+      input(editor.view, from, to, char, insert)
+    );
+
+    if (!handled) {
+      editor.view.dispatch(insert());
+    }
+  }
+
+  const markdown = serializeMarkdown(editor);
+
+  editor.destroy();
+
+  return markdown;
+};
+
+describe("strike input rule", () => {
+  it("should strike a span typed with one tilde", () => {
+    expect(typeInto("~organization~")).toBe("~~organization~~");
+  });
+
+  it("should strike a span typed with two tildes", () => {
+    expect(typeInto("~~organization~~")).toBe("~~organization~~");
+  });
+
+  it("should strike a span typed mid-sentence", () => {
+    expect(typeInto("drop ~this~ one")).toBe("drop ~~this~~ one");
+  });
+
+  it("should leave a tilde with no closer as typed", () => {
+    expect(typeInto("takes ~5 minutes")).toBe("takes ~5 minutes");
+  });
+
+  it("should leave a closer that follows a space as typed", () => {
+    expect(typeInto("~5 minutes ~")).toBe("~5 minutes ~");
   });
 });

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -51,9 +51,9 @@ export const lowlight = createLowlight({
 const NoteCode = Code.extend({ excludes: "" });
 
 /** marked's GFM `del` takes one tilde or two; TipTap's rules take only two. */
-const SINGLE_TILDE = /(?:^|\s)(~(?=[^\s~])([^~]*[^\s~])~(?!~))$/;
+const SINGLE_TILDE = /(~(?=[^\s~])([^~]*[^\s~])~(?!~))$/;
 
-const SINGLE_TILDE_PASTE = /(?:^|\s)(~(?=[^\s~])([^~]*[^\s~])~(?!~))/g;
+const SINGLE_TILDE_PASTE = /(~(?=[^\s~])([^~]*[^\s~])~(?!~))/g;
 
 const NoteStrike = Strike.extend({
   addInputRules() {

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -1,11 +1,18 @@
 import type { Editor, Extensions } from "@tiptap/core";
 
-import { Extension, InputRule, mergeAttributes } from "@tiptap/core";
+import {
+  Extension,
+  InputRule,
+  markInputRule,
+  markPasteRule,
+  mergeAttributes,
+} from "@tiptap/core";
 import { Code } from "@tiptap/extension-code";
 import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import { Image } from "@tiptap/extension-image";
 import { Link } from "@tiptap/extension-link";
 import { Paragraph } from "@tiptap/extension-paragraph";
+import { Strike } from "@tiptap/extension-strike";
 import { TableKit } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
@@ -42,6 +49,26 @@ export const lowlight = createLowlight({
  * mark, which markdown writes freely and the parser builds (`D59`).
  */
 const NoteCode = Code.extend({ excludes: "" });
+
+/** marked's GFM `del` takes one tilde or two; TipTap's rules take only two. */
+const SINGLE_TILDE = /(?:^|\s)(~(?=[^\s~])([^~]*[^\s~])~(?!~))$/;
+
+const SINGLE_TILDE_PASTE = /(?:^|\s)(~(?=[^\s~])([^~]*[^\s~])~(?!~))/g;
+
+const NoteStrike = Strike.extend({
+  addInputRules() {
+    return [
+      ...(this.parent?.() ?? []),
+      markInputRule({ find: SINGLE_TILDE, type: this.type }),
+    ];
+  },
+  addPasteRules() {
+    return [
+      ...(this.parent?.() ?? []),
+      markPasteRule({ find: SINGLE_TILDE_PASTE, type: this.type }),
+    ];
+  },
+});
 
 /**
  * Keep the paragraph around an image alone in one, and hand every other
@@ -206,10 +233,10 @@ function scrubEntities(text: string) {
 }
 
 /**
- * Scrub one line's prose, leaving backtick code spans verbatim -- inside a
- * span the entity is content the user typed, not something we generated.
+ * Inside a code span the text is content the user typed, not something we
+ * generated, so it is copied verbatim.
  */
-function scrubLine(line: string) {
+function mapLine(line: string, transform: (text: string) => string) {
   let out = "";
   let index = 0;
 
@@ -217,16 +244,16 @@ function scrubLine(line: string) {
     const tick = line.indexOf("`", index);
 
     if (tick === -1) {
-      return out + scrubEntities(line.slice(index));
+      return out + transform(line.slice(index));
     }
 
-    out += scrubEntities(line.slice(index, tick));
+    out += transform(line.slice(index, tick));
 
     const run = BACKTICK_RUN.exec(line.slice(tick))?.[0] ?? "`";
     const close = line.indexOf(run, tick + run.length);
 
     if (close === -1) {
-      return out + scrubEntities(line.slice(tick));
+      return out + transform(line.slice(tick));
     }
 
     out += line.slice(tick, close + run.length);
@@ -236,17 +263,7 @@ function scrubLine(line: string) {
   return out;
 }
 
-/**
- * Scrub the `&nbsp;` entities TipTap leaks (table cells, blank paragraphs).
- * Every markdown string that could reach a file -- or be compared against one
- * -- goes through here, so the two sides always agree.
- *
- * Code is left alone: the serializer only emits the entity in prose, so inside
- * a fence or a code span it is the author's literal text and rewriting it
- * would silently edit the file. (Raw HTML needs no such guard -- the schema
- * has no HTML node, so none survives to here.)
- */
-export function normalizeMarkdown(markdown: string) {
+function mapProse(markdown: string, transform: (text: string) => string) {
   let fence: null | string = null;
 
   return markdown
@@ -268,14 +285,88 @@ export function normalizeMarkdown(markdown: string) {
         return line;
       }
 
-      return scrubLine(line);
+      return mapLine(line, transform);
     })
     .join("\n");
 }
 
+/**
+ * Scrub the `&nbsp;` entities TipTap leaks (table cells, blank paragraphs).
+ * Every markdown string that could reach a file -- or be compared against one
+ * -- goes through here, so the two sides always agree.
+ *
+ * Code is left alone: the serializer only emits the entity in prose, so inside
+ * a fence or a code span it is the author's literal text and rewriting it
+ * would silently edit the file. (Raw HTML needs no such guard -- the schema
+ * has no HTML node, so none survives to here.)
+ */
+export function normalizeMarkdown(markdown: string) {
+  return mapProse(markdown, scrubEntities);
+}
+
+/** What upstream escapes in a text node, minus the backslash. */
+const TEXT_ESCAPE = new Set(["`", "*", "_", "[", "]", "~"]);
+
+/**
+ * A `\\` pair is left alone, which keeps `escapeMarkdownTitle`'s output and an
+ * author's literal backslash intact.
+ */
+function dropEscapes(text: string) {
+  let out = "";
+  let index = 0;
+
+  while (index < text.length) {
+    const next = text[index + 1];
+
+    if (text[index] !== "\\" || next === undefined) {
+      out += text[index];
+      index += 1;
+    } else if (next === "\\") {
+      out += "\\\\";
+      index += 2;
+    } else if (TEXT_ESCAPE.has(next)) {
+      out += next;
+      index += 2;
+    } else {
+      out += "\\";
+      index += 1;
+    }
+  }
+
+  return out;
+}
+
+type MarkdownConverter = NonNullable<Editor["markdown"]>;
+
+/**
+ * The form that goes to the file. Upstream escapes ``\ ` * _ [ ] ~`` in every
+ * text node with no regard for context, so `snake_case` gains a backslash on
+ * its first save. Re-parsing the stripped text leaves marked the authority on
+ * which escape was load-bearing, per document: one construct that needs its
+ * backslash keeps every other escape in the file with it.
+ */
+export function fileMarkdown(manager: MarkdownConverter, escaped: string) {
+  const bare = mapProse(escaped, dropEscapes);
+
+  if (bare === escaped) {
+    return escaped;
+  }
+
+  try {
+    return normalizeMarkdown(manager.serialize(manager.parse(bare))) === escaped
+      ? bare
+      : escaped;
+  } catch {
+    return escaped;
+  }
+}
+
 /** Serialize the editor to markdown for the file on disk. */
 export function serializeMarkdown(editor: Editor) {
-  return normalizeMarkdown(editor.getMarkdown());
+  const escaped = normalizeMarkdown(editor.getMarkdown());
+  const manager = editor.markdown;
+
+  return manager === undefined ? escaped : fileMarkdown(manager, escaped);
 }
 
 /** The full extension stack, shared by the component and headless tests. */
@@ -288,7 +379,11 @@ export function createEditorExtensions(
       codeBlock: false,
       link: false,
       paragraph: false,
+      strike: false,
     }),
+    // Swapped with NoteCode, a text node carrying both marks serializes its
+    // tildes inside the backticks and edits the file on open (`D59`).
+    NoteStrike,
     NoteCode,
     NoteLink.configure({ openOnClick: false }),
     NoteParagraph,

--- a/src/components/editor/markdown-roundtrip.spec.ts
+++ b/src/components/editor/markdown-roundtrip.spec.ts
@@ -98,7 +98,23 @@ describe("markdown round-trip", () => {
     ["attachment link", "[my notes.pdf](attachments/my%20notes.pdf)"],
     ["horizontal rule", "---"],
     ["wikilink", "see [[grocery list]] for details"],
+    ["literal tilde", "takes approx ~5 minutes"],
+    ["literal underscore", "the snake_case name"],
+    ["literal asterisk", "2 * 3 = 6"],
+    ["literal bracket", "the [draft] copy"],
+    ["escaped tilde a strike would eat", "\\~one\\~"],
+    ["escaped asterisks emphasis would eat", "\\*one\\*"],
   ])("should round-trip %s", (_name, markdown) => {
+    expect(roundtrip(markdown)).toBe(markdown);
+  });
+
+  it("should canonicalize a single-tilde strike read from a file", () => {
+    expect(roundtrip("~organization~")).toBe("~~organization~~");
+  });
+
+  it("should keep a note escaped when one construct needs its backslash", () => {
+    const markdown = "the snake\\_case name\n\n![notes \\].png](notes.png)";
+
     expect(roundtrip(markdown)).toBe(markdown);
   });
 

--- a/src/components/editor/sentinel.spec.ts
+++ b/src/components/editor/sentinel.spec.ts
@@ -1,7 +1,12 @@
 import { Editor } from "@tiptap/core";
 import { describe, expect, it } from "vitest";
 
-import { createEditorExtensions, serializeMarkdown } from "./extensions";
+import {
+  createEditorExtensions,
+  fileMarkdown,
+  normalizeMarkdown,
+  serializeMarkdown,
+} from "./extensions";
 import { findSentinel, insertSentinel, SENTINEL } from "./sentinel";
 
 function makeEditor(content: string) {
@@ -120,11 +125,12 @@ describe("source -> rich caret mapping", () => {
     // The stripped buffer serializes to the canonical clean form -- the
     // same comparison the runtime corruption guard makes (must NOT fire).
     const manager = requireManager(editor);
-    const canonical: string = manager.serialize(manager.parse(markdown));
-
-    expect(serializeMarkdown(editor).trimEnd()).toBe(
-      canonical.replaceAll(/&nbsp;|&#160;/g, " ").trimEnd()
+    const canonical = fileMarkdown(
+      manager,
+      normalizeMarkdown(manager.serialize(manager.parse(markdown)))
     );
+
+    expect(serializeMarkdown(editor).trimEnd()).toBe(canonical.trimEnd());
 
     editor.destroy();
   });
@@ -138,7 +144,10 @@ describe("source -> rich caret mapping", () => {
     editor.view.dispatch(editor.state.tr.delete(pos, pos + 1));
 
     const manager = requireManager(editor);
-    const canonical: string = manager.serialize(manager.parse(markdown));
+    const canonical = fileMarkdown(
+      manager,
+      normalizeMarkdown(manager.serialize(manager.parse(markdown)))
+    );
 
     // The stripped buffer no longer serializes to the canonical form --
     // exactly the condition the corruption guard reparses on.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating strikethrough text with single or double tildes.
  * Strikethrough formatting is consistently saved using double tildes.
  * Improved handling of Markdown punctuation so literal characters remain unchanged when editing, copying, and saving.
  * Preserved formatting and backslashes in code, fenced blocks, and attachment names.

* **Documentation**
  * Updated the editor specification to describe strikethrough syntax and context-sensitive escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->