### PR TITLE
fix: 🐛 enforce the 120 cap on filenames

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - First launch creates the notes dir, `.notras/`, and `.notras/index.db`, then scans the folder.
 - A note is a file whose extension is `md` or `markdown`. The match is case-sensitive, so `NOTE.MD` is invisible to the app.
 - A folder is a directory. Any path segment starting with a dot is skipped, so `.notras/` never indexes itself. Symlinks are never indexed.
-- A new note is `untitled.md` in the notes root. A name already taken takes the next free `untitled-2`, then `untitled-3`.
+- A new note is `untitled.md` in the notes root. A name already taken takes the next free `untitled-2`, then `untitled-3`. The suffixed name stays within 120 characters, with the base cut to make room.
 - Creating a note is atomic. Losing the race reports that a note already exists at that path, and leaves no partial file.
 - A path segment carries no `/`, `\` or `:`, is not blank, and does not start with a dot. A folder name is at most 120 characters.
 - The title resolves from frontmatter `title:`, then the body's leading `#` heading, then the filename with its extension stripped.

--- a/src/core/notes.spec.ts
+++ b/src/core/notes.spec.ts
@@ -6,6 +6,7 @@ import {
   NOTE_SEGMENT_PATTERN,
   resolveTitle,
   retitleLeadingHeading,
+  suffixedFilename,
 } from "./notes";
 
 /**
@@ -156,5 +157,24 @@ describe("filenameFromTitle", () => {
     for (const title of titles) {
       expect(filenameFromTitle(title)).toMatch(NOTE_SEGMENT_PATTERN);
     }
+  });
+});
+
+describe("suffixedFilename", () => {
+  it("should append the counter when the base has room", () => {
+    expect(suffixedFilename("untitled", 2)).toBe("untitled-2");
+  });
+
+  it("should cut the base so the suffix fits under the cap", () => {
+    const filename = suffixedFilename("a".repeat(120), 10);
+
+    expect(filename).toHaveLength(120);
+    expect(filename.endsWith("-10")).toBe(true);
+  });
+
+  it("should leave no separator run where the cut landed", () => {
+    const filename = suffixedFilename(`${"a".repeat(117)}-bc`, 2);
+
+    expect(filename).toBe(`${"a".repeat(117)}-2`);
   });
 });

--- a/src/core/notes.ts
+++ b/src/core/notes.ts
@@ -22,6 +22,8 @@ export interface NoteFilters {
 /** Valid path segment: no separators or colons, not hidden, not blank. */
 export const NOTE_SEGMENT_PATTERN = /^(?!\.)[^/\\:]+$/;
 
+export const NOTE_NAME_MAX_LENGTH = 120;
+
 const MARKDOWN_EXTENSION = /\.(?:md|markdown)$/i;
 
 export function noteTitle(path: string) {
@@ -128,11 +130,23 @@ export function filenameFromTitle(title: string) {
     .toLowerCase()
     .replaceAll(/[\s"*/:<>?\\|\p{Cc}]+/gu, "-")
     .replaceAll(/-{2,}/g, "-")
-    .slice(0, 120)
+    .slice(0, NOTE_NAME_MAX_LENGTH)
     .replace(LEADING_DOTS_OR_HYPHENS, "")
     .replace(TRAILING_DOTS_OR_HYPHENS, "");
 
   return slug === "" ? "untitled" : slug;
+}
+
+/** `base-counter`, cut to fit `NOTE_NAME_MAX_LENGTH`. */
+export function suffixedFilename(base: string, counter: number) {
+  const suffix = `-${counter}`;
+  const room = NOTE_NAME_MAX_LENGTH - suffix.length;
+  const stem =
+    base.length > room
+      ? base.slice(0, room).replace(TRAILING_DOTS_OR_HYPHENS, "")
+      : base;
+
+  return `${stem}${suffix}`;
 }
 
 /**

--- a/src/server/schemas/note-schemas.ts
+++ b/src/server/schemas/note-schemas.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 
-import { NOTE_SEGMENT_PATTERN } from "@/core/notes";
+import { NOTE_NAME_MAX_LENGTH, NOTE_SEGMENT_PATTERN } from "@/core/notes";
 
 const LINE_BREAK = /[\n\r]/;
 
@@ -25,8 +25,8 @@ export const noteTitleSchema = Schema.Trim.pipe(
 export const noteFilenameSchema = Schema.Trim.pipe(
   Schema.check(
     Schema.isMinLength(1, { message: "filename is required" }),
-    Schema.isMaxLength(120, {
-      message: "filename must be 120 characters or fewer",
+    Schema.isMaxLength(NOTE_NAME_MAX_LENGTH, {
+      message: `filename must be ${NOTE_NAME_MAX_LENGTH} characters or fewer`,
     }),
     Schema.isPattern(NOTE_SEGMENT_PATTERN, {
       message: String.raw`filename cannot contain / \ : or start with a dot`,
@@ -36,8 +36,8 @@ export const noteFilenameSchema = Schema.Trim.pipe(
 
 export const folderNameSchema = Schema.Trim.pipe(
   Schema.check(
-    Schema.isMaxLength(120, {
-      message: "folder must be 120 characters or fewer",
+    Schema.isMaxLength(NOTE_NAME_MAX_LENGTH, {
+      message: `folder must be ${NOTE_NAME_MAX_LENGTH} characters or fewer`,
     }),
     // Returning a string is the single-argument way to attach a message (the
     // annotations overload trips unicorn/no-array-method-this-argument).

--- a/src/server/services/note-service.spec.ts
+++ b/src/server/services/note-service.spec.ts
@@ -138,6 +138,18 @@ describe("noteService.create", () => {
     expect(path).toBe("untitled-3.md");
   });
 
+  it("should keep a deduped filename within the cap", async () => {
+    const harness = makeHarness({
+      [`${"a".repeat(120)}.md`]: "taken",
+    });
+
+    const path = await harness.run(
+      NoteService.use((svc) => svc.create({ filename: "a".repeat(120) }))
+    );
+
+    expect(path).toBe(`${"a".repeat(118)}-2.md`);
+  });
+
   it.each([["a/b"], [String.raw`a\b`], ["a:b"], [".hidden"]])(
     "should reject the filename %s",
     async (filename) => {

--- a/src/server/services/note-service.ts
+++ b/src/server/services/note-service.ts
@@ -17,6 +17,7 @@ import {
   noteTitle,
   resolveTitle,
   retitleLeadingHeading,
+  suffixedFilename,
 } from "@/core/notes";
 import { NoteRepository } from "@/server/repositories/note-repository";
 
@@ -120,7 +121,7 @@ const makeNoteService = Effect.gen(function* () {
 
     while (yield* fileStore.exists(notePath(folder, filename))) {
       counter += 1;
-      filename = `${baseFilename}-${counter}`;
+      filename = suffixedFilename(baseFilename, counter);
     }
 
     const path = notePath(folder, filename);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * New notes with long titles are limited to 120 characters while preserving readable numeric suffixes for duplicate names.
  * Filename and folder length validation now consistently uses the shared 120-character limit.
  * Duplicate note names receive truncated suffixes without exceeding the maximum length.

* **Tests**
  * Added coverage for filename suffixes, truncation, separator cleanup, and duplicate note creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->