### PR TITLE
fix: 🐛 open with inside the vault opens a note

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -63,7 +63,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - A lone tab does not reorder. Pressing and moving it moves the window, and double-clicking it zooms.
 - Tabs that overflow the strip collapse into a count beside `+`, and picking one shows it.
 - The tab context menu offers close, close others, close to the right, and copy path. The last three have no shortcut.
-- A file opened through "Open With" is an external tab: labelled by its basename in mono, saved to its own path, absent from the index, and carrying no pin, tags, rename, move, delete, or reveal. Its relative images do not render and its wikilinks do not navigate.
+- A file opened through "Open With" from outside the notes dir is an external tab: labelled by its basename in mono, saved to its own path, absent from the index, and carrying no pin, tags, rename, move, delete, or reveal. Its relative images do not render and its wikilinks do not navigate. One inside the notes dir opens as the note it is, landing on the tab already holding it when one does.
 - Quitting and relaunching restores the open tabs, which one was active, and each tab's caret. Scroll position, undo history, and source mode do not survive. A store that does not parse is discarded whole.
 - With nothing to restore, the most recently updated note opens.
 
@@ -142,7 +142,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - Closing either window hides it. Quitting is what exits.
 - A quit is held until every open buffer has flushed. A buffer that could not write cancels the quit and says so. A buffer whose file is gone reports the quit as safe while still holding text, and its banner is the only warning.
 - If the webview never answers, the quit goes through after 5 seconds.
-- "Open With" opens each markdown file in its own tab, however many are picked at once. macOS only.
+- "Open With" opens each markdown file in its own tab, however many are picked at once: inside the notes dir as its note, outside as an external tab. macOS only.
 - Settings exposes the notes folder and launch at login. Changing the folder creates its `.notras/`, builds an index, restarts the watcher, and stores the choice.
 - The webview cannot write the index. A statement SQLite does not report as read-only is refused.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -65,6 +65,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - The tab context menu offers close, close others, close to the right, and copy path. The last three have no shortcut.
 - A file opened through "Open With" from outside the notes dir is an external tab: labelled by its basename in mono, saved to its own path, absent from the index, and carrying no pin, tags, rename, move, delete, or reveal. Its relative images do not render and its wikilinks do not navigate. One inside the notes dir opens as the note it is, landing on the tab already holding it when one does.
 - Quitting and relaunching restores the open tabs, which one was active, and each tab's caret. Scroll position, undo history, and source mode do not survive. A store that does not parse is discarded whole.
+- An external tab restored for a file inside the notes dir comes back as that note, and drops out when the note is already open in another tab.
 - With nothing to restore, the most recently updated note opens.
 
 ## Search and the palette

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,6 +268,7 @@ pub fn run() {
             notes::attach_file,
             notes::attach_image,
             notes::cancel_quit,
+            notes::classify_open_paths,
             notes::db_select,
             notes::delete_note,
             notes::get_notes_dir,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -463,14 +463,26 @@ fn classify_open(notes_dir: &Path, path: String) -> PendingOpen {
     }
 }
 
+fn classify_opens(notes_dir: &Path, paths: Vec<String>) -> Vec<PendingOpen> {
+    paths
+        .into_iter()
+        .map(|path| classify_open(notes_dir, path))
+        .collect()
+}
+
+/// The kind each restored external tab is today, so a store an older build
+/// wrote does not keep a vault note as an external tab.
+#[tauri::command]
+pub fn classify_open_paths(state: State<'_, AppState>, paths: Vec<String>) -> Vec<PendingOpen> {
+    let core = state.core.lock().unwrap();
+    classify_opens(&core.notes_dir, paths)
+}
+
 #[tauri::command]
 pub fn pending_open_files(state: State<'_, AppState>) -> Vec<PendingOpen> {
     let paths = std::mem::take(&mut *state.pending_open.lock().unwrap());
     let core = state.core.lock().unwrap();
-    paths
-        .into_iter()
-        .map(|path| classify_open(&core.notes_dir, path))
-        .collect()
+    classify_opens(&core.notes_dir, paths)
 }
 
 /// Called by the frontend once it has flushed pending writes, in answer to the

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -440,9 +440,37 @@ pub fn reindex_all(
     Ok(changed)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OpenKind {
+    External,
+    Note,
+}
+
+/// A queued "Open With" path, classified so the webview opens it as the tab
+/// kind the file already is: a note inside the notes dir, external otherwise.
+#[derive(Debug, PartialEq, Serialize)]
+pub struct PendingOpen {
+    pub kind: OpenKind,
+    pub path: String,
+}
+
+fn classify_open(notes_dir: &Path, path: String) -> PendingOpen {
+    let host = Path::new(&path);
+    match index::relative_path(notes_dir, host).filter(|_| index::is_note_file(host)) {
+        Some(rel) => PendingOpen { kind: OpenKind::Note, path: rel },
+        None => PendingOpen { kind: OpenKind::External, path },
+    }
+}
+
 #[tauri::command]
-pub fn pending_open_files(state: State<'_, AppState>) -> Vec<String> {
-    std::mem::take(&mut *state.pending_open.lock().unwrap())
+pub fn pending_open_files(state: State<'_, AppState>) -> Vec<PendingOpen> {
+    let paths = std::mem::take(&mut *state.pending_open.lock().unwrap());
+    let core = state.core.lock().unwrap();
+    paths
+        .into_iter()
+        .map(|path| classify_open(&core.notes_dir, path))
+        .collect()
 }
 
 /// Called by the frontend once it has flushed pending writes, in answer to the
@@ -582,5 +610,46 @@ mod tests {
 
         assert_eq!(error.kind, ErrorKind::Failed);
         assert_eq!(error.message, "invalid note path: ../escape");
+    }
+    #[test]
+    fn classifies_a_vault_file_as_a_note() {
+        let open = classify_open(Path::new("/vault"), "/vault/work/a.md".into());
+
+        assert_eq!(open, PendingOpen { kind: OpenKind::Note, path: "work/a.md".into() });
+    }
+
+    #[test]
+    fn classifies_a_file_outside_the_vault_as_external() {
+        let open = classify_open(Path::new("/vault"), "/elsewhere/a.md".into());
+
+        assert_eq!(open, PendingOpen { kind: OpenKind::External, path: "/elsewhere/a.md".into() });
+    }
+
+    #[test]
+    fn a_sibling_dir_sharing_the_prefix_is_outside_the_vault() {
+        let open = classify_open(Path::new("/vault"), "/vault-archive/a.md".into());
+
+        assert_eq!(open.kind, OpenKind::External);
+    }
+
+    #[test]
+    fn a_hidden_segment_inside_the_vault_is_external() {
+        let open = classify_open(Path::new("/vault"), "/vault/.drafts/a.md".into());
+
+        assert_eq!(open.kind, OpenKind::External);
+    }
+
+    #[test]
+    fn a_non_markdown_file_inside_the_vault_is_external() {
+        let open = classify_open(Path::new("/vault"), "/vault/a.txt".into());
+
+        assert_eq!(open.kind, OpenKind::External);
+    }
+
+    #[test]
+    fn an_uppercase_extension_inside_the_vault_is_external() {
+        let open = classify_open(Path::new("/vault"), "/vault/NOTE.MD".into());
+
+        assert_eq!(open.kind, OpenKind::External);
     }
 }

--- a/src/lib/tabs/store.spec.ts
+++ b/src/lib/tabs/store.spec.ts
@@ -139,6 +139,25 @@ describe("adoptVaultNotes", () => {
     ]);
   });
 
+  it("should keep the restored tabs when the classifier rejects", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      serializeTabs({
+        activeId: "kept-x",
+        carets: {},
+        tabs: [{ id: "kept-x", kind: "external", path: "/vault/a.md" }],
+      })
+    );
+    restoreTabs();
+
+    await expect(
+      adoptVaultNotes(() => Promise.reject(new Error("no answer")))
+    ).rejects.toThrow("no answer");
+    expect(getTabState().tabs).toStrictEqual([
+      { id: "kept-x", kind: "external", path: "/vault/a.md" },
+    ]);
+  });
+
   it("should not ask when no external tab was restored", async () => {
     localStorage.setItem(
       STORAGE_KEY,

--- a/src/lib/tabs/store.spec.ts
+++ b/src/lib/tabs/store.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  adoptVaultNotes,
   closeTab,
   getTabHandles,
   getTabState,
@@ -9,7 +10,7 @@ import {
   restoredCaret,
   restoreTabs,
 } from "./store";
-import { serializeTabs } from "./tab";
+import { parseTabs, serializeTabs } from "./tab";
 
 const STORAGE_KEY = "tabs";
 
@@ -89,6 +90,69 @@ describe("restoreTabs", () => {
     expect(getTabState().activeId).toBe(b?.id);
     expect(restoredCaret(a?.id ?? "")).toBe(12);
     expect(restoredCaret(b?.id ?? "")).toBe(34);
+  });
+});
+
+describe("adoptVaultNotes", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("should adopt an external tab the classifier calls a note", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      serializeTabs({
+        activeId: "kept-x",
+        carets: {},
+        tabs: [{ id: "kept-x", kind: "external", path: "/vault/a.md" }],
+      })
+    );
+    restoreTabs();
+
+    await adoptVaultNotes(async () => [{ kind: "note", path: "a.md" }]);
+
+    expect(getTabState().tabs).toStrictEqual([
+      { id: "kept-x", kind: "note", path: "a.md" },
+    ]);
+    expect(
+      parseTabs(localStorage.getItem(STORAGE_KEY) ?? "")?.tabs
+    ).toStrictEqual([{ id: "kept-x", kind: "note", path: "a.md" }]);
+  });
+
+  it("should leave alone a tab the classifier keeps external", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      serializeTabs({
+        activeId: "kept-x",
+        carets: {},
+        tabs: [{ id: "kept-x", kind: "external", path: "/elsewhere/a.md" }],
+      })
+    );
+    restoreTabs();
+
+    await adoptVaultNotes(async (paths) =>
+      paths.map((path) => ({ kind: "external", path }))
+    );
+
+    expect(getTabState().tabs).toStrictEqual([
+      { id: "kept-x", kind: "external", path: "/elsewhere/a.md" },
+    ]);
+  });
+
+  it("should not ask when no external tab was restored", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      serializeTabs({
+        activeId: "kept-a",
+        carets: {},
+        tabs: [{ id: "kept-a", kind: "note", path: "a.md" }],
+      })
+    );
+    restoreTabs();
+
+    await adoptVaultNotes(() => Promise.reject(new Error("asked")));
+
+    expect(getTabState().tabs.map((tab) => tab.id)).toStrictEqual(["kept-a"]);
   });
 });
 

--- a/src/lib/tabs/store.ts
+++ b/src/lib/tabs/store.ts
@@ -2,9 +2,10 @@ import { batch, createStore, useSelector } from "@tanstack/react-store";
 
 import type { SaveStatus } from "@/components/editor/use-autosave";
 
-import type { ClosedTab, Tab, TabState } from "./tab";
+import type { ClosedTab, PendingOpen, Tab, TabState } from "./tab";
 
 import {
+  adoptNote,
   closeTab as closeInList,
   legacyTabId,
   moveTabTo,
@@ -159,6 +160,33 @@ export function restoreTabs() {
   }));
 
   return true;
+}
+
+/**
+ * A store an older build wrote holds a vault note opened through "Open With"
+ * as an external tab. Ask which restored external tabs are notes today and
+ * adopt those, so one file never carries two sessions.
+ */
+export async function adoptVaultNotes(
+  classify: (paths: string[]) => Promise<PendingOpen[]>
+) {
+  const external = getTabState().tabs.filter((tab) => tab.kind === "external");
+
+  if (external.length === 0) {
+    return;
+  }
+
+  const classified = await classify(external.map((tab) => tab.path));
+
+  setState(
+    external.reduce((state, tab, index) => {
+      const open = classified[index];
+
+      return open?.kind === "note"
+        ? adoptNote(state, tab.id, open.path)
+        : state;
+    }, getTabState())
+  );
 }
 
 /**

--- a/src/lib/tabs/tab.spec.ts
+++ b/src/lib/tabs/tab.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { TabState } from "./tab";
 
 import {
+  adoptNote,
   closeTab,
   moveTabTo,
   openTab,
@@ -169,6 +170,39 @@ describe("replaceNotePath", () => {
 
   it("should ignore a path that is not open", () => {
     expect(replaceNotePath(three, "z.md", "y.md")).toStrictEqual(three);
+  });
+});
+
+describe("adoptNote", () => {
+  it("should turn the external tab into the note, keeping its id", () => {
+    const state: TabState = {
+      activeId: "id-external-/vault/b.md",
+      tabs: [note("a.md"), external("/vault/b.md")],
+    };
+
+    const next = adoptNote(state, "id-external-/vault/b.md", "b.md");
+
+    expect(next.tabs).toStrictEqual([
+      note("a.md"),
+      { id: "id-external-/vault/b.md", kind: "note", path: "b.md" },
+    ]);
+    expect(next.activeId).toBe("id-external-/vault/b.md");
+  });
+
+  it("should collapse onto the note when it is already open", () => {
+    const state: TabState = {
+      activeId: "id-external-/vault/a.md",
+      tabs: [note("a.md"), external("/vault/a.md")],
+    };
+
+    const next = adoptNote(state, "id-external-/vault/a.md", "a.md");
+
+    expect(next.tabs).toStrictEqual([note("a.md")]);
+    expect(next.activeId).toBe("id-a.md");
+  });
+
+  it("should ignore an id that is not open", () => {
+    expect(adoptNote(three, "id-missing", "z.md")).toStrictEqual(three);
   });
 });
 

--- a/src/lib/tabs/tab.ts
+++ b/src/lib/tabs/tab.ts
@@ -14,6 +14,12 @@ export interface Tab {
   path: string;
 }
 
+/** A queued or restored path with the tab kind Rust chose for it. */
+export interface PendingOpen {
+  kind: Tab["kind"];
+  path: string;
+}
+
 /** The open set and which one is showing. An empty `activeId` means no tabs. */
 export interface TabState {
   activeId: string;
@@ -156,6 +162,34 @@ export function replaceNotePath(
   return {
     activeId: state.activeId,
     tabs: state.tabs.with(index, { ...moved, path: to }),
+  };
+}
+
+/**
+ * Turn the external tab `id` into the note at `path`, collapsing onto that
+ * note's tab when it is already open. A store written before Rust classified
+ * "Open With" paths holds a vault note this way.
+ */
+export function adoptNote(state: TabState, id: string, path: string): TabState {
+  const index = indexOfId(state.tabs, id);
+  const adopted = state.tabs[index];
+
+  if (adopted === undefined) {
+    return state;
+  }
+
+  const existing = state.tabs[indexOfFile(state.tabs, "note", path)];
+
+  if (existing !== undefined) {
+    return {
+      activeId: state.activeId === adopted.id ? existing.id : state.activeId,
+      tabs: state.tabs.toSpliced(index, 1),
+    };
+  }
+
+  return {
+    activeId: state.activeId,
+    tabs: state.tabs.with(index, { ...adopted, kind: "note", path }),
   };
 }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,7 +18,7 @@ import { createNote } from "@/data/create-note";
 import { noteQueries, notesDirQuery } from "@/data/queries";
 import { flushPendingWrites } from "@/lib/pending-flush";
 import { openNote, openTab, persistTabs } from "@/lib/tabs/store";
-import type { Tab } from "@/lib/tabs/tab";
+import type { PendingOpen } from "@/lib/tabs/tab";
 import { errorMessage } from "@/lib/ui/failure";
 import { findUpdate, offerUpdate, updatesSupported } from "@/lib/updater";
 
@@ -52,11 +52,6 @@ export const Route = createRootRouteWithContext<{
     ]);
   },
 });
-
-interface PendingOpen {
-  kind: Tab["kind"];
-  path: string;
-}
 
 /** `listen` resolves to its own unsubscribe, which every effect here drops. */
 function disposeLater(...pending: Promise<() => void>[]) {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { createNote } from "@/data/create-note";
 import { noteQueries, notesDirQuery } from "@/data/queries";
 import { flushPendingWrites } from "@/lib/pending-flush";
 import { openNote, openTab, persistTabs } from "@/lib/tabs/store";
+import type { Tab } from "@/lib/tabs/tab";
 import { errorMessage } from "@/lib/ui/failure";
 import { findUpdate, offerUpdate, updatesSupported } from "@/lib/updater";
 
@@ -51,6 +52,11 @@ export const Route = createRootRouteWithContext<{
     ]);
   },
 });
+
+interface PendingOpen {
+  kind: Tab["kind"];
+  path: string;
+}
 
 /** `listen` resolves to its own unsubscribe, which every effect here drops. */
 function disposeLater(...pending: Promise<() => void>[]) {
@@ -175,10 +181,10 @@ function RootLayout() {
     // something in it, so draining is the single delivery mechanism. Each one
     // lands in its own tab rather than replacing what is open (`D54`).
     const drainPendingOpens = async () => {
-      const paths = await invoke<string[]>("pending_open_files");
+      const opens = await invoke<PendingOpen[]>("pending_open_files");
 
-      for (const path of paths) {
-        openTab("external", path, true);
+      for (const { kind, path } of opens) {
+        openTab(kind, path, true);
       }
     };
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { useHotkey, useHotkeys } from "@tanstack/react-hotkeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect } from "react";
 import { Chord } from "@/components/chord";
@@ -18,6 +19,7 @@ import { noteQueries } from "@/data/queries";
 import { togglePref, usePref } from "@/lib/prefs";
 import {
   activateTab,
+  adoptVaultNotes,
   closeTab,
   getTabHandles,
   getTabState,
@@ -28,7 +30,7 @@ import {
   useTabSnapshot,
   useTabState,
 } from "@/lib/tabs/store";
-import type { Tab } from "@/lib/tabs/tab";
+import type { PendingOpen, Tab } from "@/lib/tabs/tab";
 import { stepTab, tabId } from "@/lib/tabs/tab";
 import { errorMessage } from "@/lib/ui/failure";
 import { attachmentLink } from "@/lib/utils/attachments";
@@ -51,6 +53,10 @@ export const Route = createFileRoute("/")({
     // A restored path that no longer reads closes its own tab, so nothing is
     // checked against disk here.
     if (restoreTabs()) {
+      await adoptVaultNotes((paths) =>
+        invoke<PendingOpen[]>("classify_open_paths", { paths })
+      );
+
       return;
     }
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -53,9 +53,16 @@ export const Route = createFileRoute("/")({
     // A restored path that no longer reads closes its own tab, so nothing is
     // checked against disk here.
     if (restoreTabs()) {
-      await adoptVaultNotes((paths) =>
-        invoke<PendingOpen[]>("classify_open_paths", { paths })
-      );
+      try {
+        await adoptVaultNotes((paths) =>
+          invoke<PendingOpen[]>("classify_open_paths", { paths })
+        );
+      } catch (error) {
+        toast.add({
+          title: errorMessage(error, "could not check restored tabs"),
+          type: "error",
+        });
+      }
 
       return;
     }


### PR DESCRIPTION
🏁 Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - “Open With” opens notes-directory files as note tabs and external files as external tabs.
  - Restored external tabs are reclassified when they belong to the notes directory.
  - Reopening an already open note reuses its existing tab.
  - macOS supports opening multiple Markdown files at once, with each file in its own tab.
- **Bug Fixes**
  - Improved classification for hidden paths, similarly named directories, unsupported extensions, and Markdown files.
  - Restored tabs remain unchanged and display an error notification if classification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->