### PR TITLE
fix: 🐛  index markdown files whatever the extension case

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 
 - Notes live in one directory. It defaults to `~/notras` and settings changes it. The choice is stored in Tauri's `settings.json`.
 - First launch creates the notes dir, `.notras/`, and `.notras/index.db`, then scans the folder.
-- A note is a file whose extension is `md` or `markdown`. The match is case-sensitive, so `NOTE.MD` is invisible to the app.
+- A note is a file whose extension is `md` or `markdown`, matched without regard to case, so `NOTE.MD` is a note.
 - A folder is a directory. Any path segment starting with a dot is skipped, so `.notras/` never indexes itself. Symlinks are never indexed.
 - A new note is `untitled.md` in the notes root. A name already taken takes the next free `untitled-2`, then `untitled-3`. The suffixed name stays within 120 characters, with the base cut to make room.
 - Creating a note is atomic. Losing the race reports that a note already exists at that path, and leaves no partial file.

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -43,10 +43,9 @@ fn timestamp_millis(time: std::io::Result<std::time::SystemTime>) -> Option<i64>
 }
 
 pub fn is_note_file(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|ext| ext.to_str()),
-        Some("md" | "markdown")
-    )
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
 }
 
 fn is_hidden(component: &std::ffi::OsStr) -> bool {
@@ -560,6 +559,23 @@ mod tests {
         fs::remove_file(dir.join("ideas.md")).unwrap();
         let changed = scan_all(&conn, &dir).unwrap();
         assert_eq!(changed, vec!["ideas.md".to_string()]);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn indexes_an_uppercase_extension() {
+        let dir = temp_notes_dir("uppercase");
+        fs::write(dir.join("NOTE.MD"), "# shouted\n").unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        assert_eq!(scan_all(&conn, &dir).unwrap().len(), 1);
+
+        let rows = select(&conn, "SELECT path, title FROM note", &[]).unwrap();
+        assert_eq!(rows[0][0], json!("NOTE.MD"));
+        assert_eq!(rows[0][1], json!("shouted"));
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -659,9 +659,9 @@ mod tests {
     }
 
     #[test]
-    fn an_uppercase_extension_inside_the_vault_is_external() {
+    fn an_uppercase_extension_inside_the_vault_is_a_note() {
         let open = classify_open(Path::new("/vault"), "/vault/NOTE.MD".into());
 
-        assert_eq!(open.kind, OpenKind::External);
+        assert_eq!(open, PendingOpen { kind: OpenKind::Note, path: "NOTE.MD".into() });
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Note files with uppercase `.MD` or `.MARKDOWN` extensions are now recognized and indexed correctly.
  - Uppercase-extension notes are correctly classified as internal notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->