### PR TITLE
fix: 🐛 resolve symlinks before classifying open with

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -143,7 +143,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - Closing either window hides it. Quitting is what exits.
 - A quit is held until every open buffer has flushed. A buffer that could not write cancels the quit and says so. A buffer whose file is gone reports the quit as safe while still holding text, and its banner is the only warning.
 - If the webview never answers, the quit goes through after 5 seconds.
-- "Open With" opens each markdown file in its own tab, however many are picked at once: inside the notes dir as its note, outside as an external tab. A path that reaches the notes dir through a symlink or a firmlink counts as inside it. macOS only.
+- "Open With" opens each markdown file in its own tab, however many are picked at once: inside the notes dir as its note, outside as an external tab. A path that reaches the notes dir through a symlink counts as inside it. macOS only.
 - Settings exposes the notes folder and launch at login. Changing the folder creates its `.notras/`, builds an index, restarts the watcher, and stores the choice.
 - The webview cannot write the index. A statement SQLite does not report as read-only is refused.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -143,7 +143,7 @@ What notras does. Every claim below is checkable against a running build, so a c
 - Closing either window hides it. Quitting is what exits.
 - A quit is held until every open buffer has flushed. A buffer that could not write cancels the quit and says so. A buffer whose file is gone reports the quit as safe while still holding text, and its banner is the only warning.
 - If the webview never answers, the quit goes through after 5 seconds.
-- "Open With" opens each markdown file in its own tab, however many are picked at once: inside the notes dir as its note, outside as an external tab. macOS only.
+- "Open With" opens each markdown file in its own tab, however many are picked at once: inside the notes dir as its note, outside as an external tab. A path that reaches the notes dir through a symlink or a firmlink counts as inside it. macOS only.
 - Settings exposes the notes folder and launch at login. Changing the folder creates its `.notras/`, builds an index, restarts the watcher, and stores the choice.
 - The webview cannot write the index. A statement SQLite does not report as read-only is refused.
 

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -456,17 +456,18 @@ pub struct PendingOpen {
 }
 
 fn classify_open(notes_dir: &Path, path: String) -> PendingOpen {
-    let host = Path::new(&path);
-    match index::relative_path(notes_dir, host).filter(|_| index::is_note_file(host)) {
+    let host = fs::canonicalize(&path).unwrap_or_else(|_| PathBuf::from(&path));
+    match index::relative_path(notes_dir, &host).filter(|_| index::is_note_file(&host)) {
         Some(rel) => PendingOpen { kind: OpenKind::Note, path: rel },
         None => PendingOpen { kind: OpenKind::External, path },
     }
 }
 
 fn classify_opens(notes_dir: &Path, paths: Vec<String>) -> Vec<PendingOpen> {
+    let notes_dir = fs::canonicalize(notes_dir).unwrap_or_else(|_| notes_dir.to_path_buf());
     paths
         .into_iter()
-        .map(|path| classify_open(notes_dir, path))
+        .map(|path| classify_open(&notes_dir, path))
         .collect()
 }
 
@@ -663,5 +664,23 @@ mod tests {
         let open = classify_open(Path::new("/vault"), "/vault/NOTE.MD".into());
 
         assert_eq!(open, PendingOpen { kind: OpenKind::Note, path: "NOTE.MD".into() });
+    }
+    #[test]
+    #[cfg(unix)]
+    fn classifies_through_a_symlinked_notes_dir() {
+        let real = scratch_dir("symlink-real");
+        fs::write(real.join("a.md"), "").unwrap();
+        let link = std::env::temp_dir().join(format!("notras-test-symlink-link-{}", std::process::id()));
+        let _ = fs::remove_file(&link);
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let through_link = classify_opens(&link, vec![real.join("a.md").to_string_lossy().to_string()]);
+        let through_real = classify_opens(&real, vec![link.join("a.md").to_string_lossy().to_string()]);
+
+        assert_eq!(through_link, vec![PendingOpen { kind: OpenKind::Note, path: "a.md".into() }]);
+        assert_eq!(through_real, vec![PendingOpen { kind: OpenKind::Note, path: "a.md".into() }]);
+
+        let _ = fs::remove_file(&link);
+        let _ = fs::remove_dir_all(&real);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - On macOS, symlink-resolved paths within the notes directory continue to be recognized as internal notes.
  - Firmlink-resolved paths are no longer classified as internal notes.
  - Files outside the notes directory continue to open as external tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->